### PR TITLE
Fix hardcoded reference to cfn_outputs image

### DIFF
--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -19,6 +19,7 @@ include::../{generateddir}/parameters/index.adoc[]
 . Monitor the status of the stack. When the status is *CREATE_COMPLETE*, the {partner-product-name} deployment is ready.
 . Use the values displayed in the *Outputs* tab for the stack, as shown in <<cfn_outputs>>, to view the created resources.
 
+:xrefstyle: short
 [#cfn_outputs]
 .{partner-product-name} outputs after successful deployment
 image::../images/cfn_outputs.png[cfn_outputs,width=648,height=439]

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -17,7 +17,7 @@ include::../{generateddir}/parameters/index.adoc[]
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.
 . Monitor the status of the stack. When the status is *CREATE_COMPLETE*, the {partner-product-name} deployment is ready.
-. Use the values displayed in the *Outputs* tab for the stack, as shown in figure 2, to view the created resources.
+. Use the values displayed in the *Outputs* tab for the stack, as shown in <<cfn_outputs>>, to view the created resources.
 
 [#cfn_outputs]
 .{partner-product-name} outputs after successful deployment


### PR DESCRIPTION
*Issue #, if available:*
cfn_outputs image is not linked via anchor tag, instead hardcoded.

*Description of changes:*
Fixed hardcoded reference to cfn_outputs image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
