### PR TITLE
Adding in links for templates

### DIFF
--- a/.specific/deploy_steps.adoc
+++ b/.specific/deploy_steps.adoc
@@ -25,10 +25,13 @@ NOTE: You are responsible for the cost of the AWS services used while running th
 
 . Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see link:#_deployment_options[deployment options] earlier in this guide.
 
-[cols=",]
+[cols=2*]
 |===
-|http://qs_launch_link[Deploy {partner-product-short-name} into a new VPC on AWS^]
-|http://qs_launch_link[Deploy {partner-product-short-name} into an existing VPC on AWS^]
+^|http://qs_launch_link[Deploy {partner-product-short-name} into a new VPC on AWS^]
+^|http://qs_template_link[View template^]
+
+^|http://qs_launch_link[Deploy {partner-product-short-name} into an existing VPC on AWS^]
+^|http://qs_template_link[View template^]
 |===
 
 WARNING: If you’re deploying {partner-product-short-name} into an existing VPC, make sure that your VPC has two private subnets in different Availability Zones for the workload instances, and that the subnets aren’t shared. This Quick Start doesn’t support https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[shared subnets^]. These subnets require https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html[NAT gateways^] in their route tables, to allow the instances to download packages and software without exposing them to the internet.


### PR DESCRIPTION
*Description of changes:*

In the deployment guides we usually include a template download link by the parameter tables.
This is added to be in the same table as the launch links.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
