### PR TITLE
Small updates to boilerplate docs

### DIFF
--- a/.specific/_settings.adoc
+++ b/.specific/_settings.adoc
@@ -1,15 +1,25 @@
+// Do not change this first attribute. Do change the others.
+:quickstart-team-name: AWS Quick Start team
 :quickstart-project-name: quickstart-documentation-base
 :partner-product-name: Example Product Name
 :partner-product-short-name: Example Product Name
 :partner-company-name: Example Company Name, Ltd.
 :doc-month: May
 :doc-year: 2020
-:partner-contributors: John Doe and Jane Doe - {partner-company-name}
-:quickstart-contributors: Jim Smith - AWS Global Partner SA, AWS + Joe Jones - Technical Product Manager, AWS
-:deployment_time: 30 minutes / 1 hour
+// For the following two attributes, if the partner agrees to include names in the byline, 
+// enter names for both partner-contributors and quickstart-contributors. Otherwise, 
+// delete all placeholder names: everything preceding "{partner-company-name}"  
+// and "{quickstart-team-name}". Use commas as shown in the placeholder text. 
+// Use the comma before "and" only if three or more names.
+:partner-contributors: Shuai Ye, Michael McConnell, and John Smith, {partner-company-name}
+:quickstart-contributors: Toni Jones, {quickstart-team-name}
+// For the following attribute, use minutes if deployment takes an hour or less, 
+// for example, 30 minutes or 60 minutes. 
+// Use hours for deployment times greater than 60 minutes (rounded to a quarter hour),
+// for example, 1.25 hours, 2 hours, 2.5 hours.
+:deployment_time: 15 minutes / 60 minutes / 1.5 hours
 :default_deployment_region: us-east-1
-// Uncomment these two attributes if you are leveraging
-// - an AWS Marketplace listing.
-// Additional content will be auto-generated based on these attributes.
+// Uncomment the following two attributes if you are using an AWS Marketplace listing.
+// Additional content will be generated automatically based on these attributes.
 // :marketplace_subscription:
 // :marketplace_listing_url: https://example.com/

--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -90,7 +90,7 @@ endif::template_ec2[]
 
 ==== IAM permissions
 //todo: scope of least-privilege
-Before launching the Quick Start, you must log in to the AWS Management Console with https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[IAM permissions^] for the resources and actions the templates deploy.
+Before launching the Quick Start, you must log in to the AWS Management Console with https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[IAM permissions^] for the resources that the templates deploy.
 
 The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions.
 


### PR DESCRIPTION
Acrolinx says to avoid using the word "action" when referring to an AWS operation. Vinod confirms that it makes sense to remove the word here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
