### PR TITLE
Added support for ordering entrypoints

### DIFF
--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -95,7 +95,7 @@ def just_pass():
     if not template_entrypoints:
         raise Exception("No documentation entrypoints (Metadata => QuickStartDocumentation => EntrypointName)  were found. Unable to build documentation. Exiting.")
     with open('docs/generated/parameters/index.adoc', 'w') as f:
-        for template_file, cosmetic_name in template_entrypoints.items():
+        for template_file, cosmetic_name in sorted(template_entrypoints.items(), key=lambda x: x[1]):
             f.write(f"\n=== {cosmetic_name}\n")
             f.write(f"include::{template_file}[]\n")
 

--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -102,7 +102,7 @@ def just_pass():
         raise Exception("No documentation entrypoints (Metadata => QuickStartDocumentation => EntrypointName)  were found. Unable to build documentation. Exiting.")
     with open('docs/generated/parameters/index.adoc', 'w') as f:
         for template_file, order in sorted(template_order.items(), key=lambda x: x[1]):
-            print (f"- Index - {order} - {template_entrypoints.get(template_file)}")
+            print (f"- Index - {order} - {template_entrypoints.get(template_file)} - {template_file}")
             f.write(f"\n=== {template_entrypoints.get(template_file)}\n")
             f.write(f"include::{template_file}[]\n")
 

--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -102,7 +102,7 @@ def just_pass():
         raise Exception("No documentation entrypoints (Metadata => QuickStartDocumentation => EntrypointName)  were found. Unable to build documentation. Exiting.")
     with open('docs/generated/parameters/index.adoc', 'w') as f:
         for template_file, order in sorted(template_order.items(), key=lambda x: x[1]):
-            print (f"- Index - {order} - {template_entrypoints.get(template_file)} - {template_file}")
+            print (f"Index - {order} - {template_entrypoints.get(template_file)} - {template_file}")
             f.write(f"\n=== {template_entrypoints.get(template_file)}\n")
             f.write(f"include::{template_file}[]\n")
 

--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -27,6 +27,7 @@ def _generate_per_label_table_entry(label, param, default, description):
 
 def just_pass():
     template_entrypoints = {}
+    template_order = {}
     found_files_with_glob_pattern=False
     for yaml_cfn_file in Path('./templates').glob('*.template*'):
         found_files_with_glob_pattern=True
@@ -38,9 +39,14 @@ def just_pass():
         if not entrypoint:
             print(f"- No documentation entrypoint found. Continuing.")
             continue
+        order = template.get('Metadata',{}).get('QuickStartDocumentation',{}).get('Order')
+        if not order:
+            print(f"- No documentation order found. Assigning x.")
+            order = 'x'
         _pf = Path(yaml_cfn_file).stem + ".adoc"
         p_file = f"docs/generated/parameters/{_pf}"
         template_entrypoints[p_file.split('/')[-1]] = entrypoint
+        template_order[p_file.split('/')[-1]] = str(order)
 
         label_mappings = {}
         reverse_label_mappings = {}
@@ -95,8 +101,9 @@ def just_pass():
     if not template_entrypoints:
         raise Exception("No documentation entrypoints (Metadata => QuickStartDocumentation => EntrypointName)  were found. Unable to build documentation. Exiting.")
     with open('docs/generated/parameters/index.adoc', 'w') as f:
-        for template_file, cosmetic_name in sorted(template_entrypoints.items(), key=lambda x: x[1]):
-            f.write(f"\n=== {cosmetic_name}\n")
+        for template_file, order in sorted(template_order.items(), key=lambda x: x[1]):
+            print (f"- Index - {order} - {template_entrypoints.get(template_file)}")
+            f.write(f"\n=== {template_entrypoints.get(template_file)}\n")
             f.write(f"include::{template_file}[]\n")
 
 if __name__ == '__main__':


### PR DESCRIPTION
*Issue #, if available:* 
12
*Description of changes:*
I added the option to accept an "Order" attribute from the template metadata. If the attribute is present it is used as the sorting basis for the entrypoints. The entrypoint creation will be based on the values of the Order attribute, this value is converted to a string prior to sorting. The script will output to the console the index value and entrypoint name in the order that they will appear in the documentation.
i.e.
- Index - a - Launch into a new VPC
- Index - b - Launch into an existing VPC
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
