### PR TITLE
[DO NOT MERGE] support default branch called "main"

### DIFF
--- a/.actions/asciidoctor-action/README.md
+++ b/.actions/asciidoctor-action/README.md
@@ -1,6 +1,6 @@
 # Asciidoctor GitHub Action
 
-To use this action add the below config to  **.github/workflows/adocs-build.yml**
+To use this action add the below config to  **.github/workflows/adocs-build.yml** 
 
 ```
 name: build adocs
@@ -9,6 +9,7 @@ on:
   push:
     branches:
     - master
+    - main
 jobs:
   adoc_build:
     runs-on: ubuntu-18.04

--- a/.actions/main-docs-build.yml
+++ b/.actions/main-docs-build.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
     - master
+    - main
 jobs:
   build-adocs:
     runs-on: ubuntu-18.04
     name: asciidoc builder
     steps:
-    - name: Checkout (master)
+    - name: Checkout (main)
       uses: actions/checkout@v2
     - name: Get new doc updates
       run: |
-           wget https://raw.githubusercontent.com/aws-quickstart/quickstart-documentation-base-common/master/.utils/configure_git_env.sh
+           wget https://raw.githubusercontent.com/aws-quickstart/quickstart-documentation-base-common/main/.utils/configure_git_env.sh
            chmod +x configure_git_env.sh
            ./configure_git_env.sh
     - name: Setup python

--- a/.css/quickstart.css
+++ b/.css/quickstart.css
@@ -759,13 +759,13 @@ a img {
     border: 1px solid #A4A4A4;
 }
 
-#preview_mode {
+.preview_mode {
 	border-color:#e0e0dc;
 	-webkit-box-shadow:0 1px 4px #e0e0dc;
 	box-shadow:0 1px 4px #e0e0dc;
   background:#ffffb3;
   padding-bottom: 2rem;
 }
-#preview_mode .tableblock {
+.preview_mode .tableblock {
   background:#ffffb3;
 }

--- a/.specific/THROWAWAY
+++ b/.specific/THROWAWAY
@@ -1,1 +1,0 @@
-sxdklfjdsklfj

--- a/.specific/THROWAWAY
+++ b/.specific/THROWAWAY
@@ -1,0 +1,1 @@
+sxdklfjdsklfj

--- a/.utils/Codebuild-Custom.dockerfile
+++ b/.utils/Codebuild-Custom.dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
     aws-cli \
     py3-pip \
     python3
-RUN wget https://raw.githubusercontent.com/aws-quickstart/quickstart-documentation-base-common/master/.utils/requirements.txt -O /tmp/req.txt
+RUN wget https://raw.githubusercontent.com/aws-quickstart/quickstart-documentation-base-common/main/.utils/requirements.txt -O /tmp/req.txt
 RUN ln -sf /usr/bin/pip3 /usr/bin/pip
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 RUN pip3 install -r /tmp/req.txt

--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -2,13 +2,13 @@
 set -e
 ASCIIDOC_ATTRIBUTES=""
 GITHUB_REPO_OWNER=$(echo ${GITHUB_REPOSITORY} | cut -d '/' -f 1)
+if [ -d docs/images ]; then
+  mv docs/images images
+fi
 if [ "${GITHUB_REPO_OWNER}" == "aws-quickstart" ]; then
   cp docs/boilerplate/.css/AWS-Logo.svg images/
   if [ "${GITHUB_REF}" == "refs/heads/master" ]; then
     ASCIIDOC_ATTRIBUTES="-a production_build"
   fi
-fi
-if [ -d docs/images ]; then
-  mv docs/images images
 fi
 asciidoctor --base-dir docs/ --backend=html5 -o ../index.html -w --failure-level ERROR --doctype=book -a toc2 ${ASCIIDOC_ATTRIBUTES} docs/boilerplate/index.adoc

--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -7,7 +7,7 @@ if [ -d docs/images ]; then
 fi
 if [ "${GITHUB_REPO_OWNER}" == "aws-quickstart" ]; then
   cp docs/boilerplate/.css/AWS-Logo.svg images/
-  if [ "${GITHUB_REF}" == "refs/heads/master" || "${GITHUB_REF}" == "refs/heads/main" ]; then
+  if [ "${GITHUB_REF}" == "refs/heads/master" ] || [ "${GITHUB_REF}" == "refs/heads/main" ]; then
     ASCIIDOC_ATTRIBUTES="-a production_build"
   fi
 fi

--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -7,7 +7,7 @@ if [ -d docs/images ]; then
 fi
 if [ "${GITHUB_REPO_OWNER}" == "aws-quickstart" ]; then
   cp docs/boilerplate/.css/AWS-Logo.svg images/
-  if [ "${GITHUB_REF}" == "refs/heads/master" ]; then
+  if [ "${GITHUB_REF}" == "refs/heads/master" || "${GITHUB_REF}" == "refs/heads/main" ]; then
     ASCIIDOC_ATTRIBUTES="-a production_build"
   fi
 fi

--- a/.utils/commit_and_push_to_ghpages.sh
+++ b/.utils/commit_and_push_to_ghpages.sh
@@ -5,7 +5,7 @@ set -eu
 repo_uri="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 remote_name="doc-upstream"
-main_branch="master"
+main_branch=$(basename "$(git symbolic-ref --short refs/remotes/origin/HEAD)")
 target_branch="gh-pages"
 
 cd "$GITHUB_WORKSPACE"

--- a/.utils/configure_git_env.sh
+++ b/.utils/configure_git_env.sh
@@ -2,7 +2,8 @@
 set -x
 git remote update
 git fetch
-set +e 
+set +e
+default_branch=$(basename "$(git symbolic-ref --short refs/remotes/origin/HEAD)")
 git rev-parse --verify origin/gh-pages
 CHECK_BRANCH=$?
 set -e
@@ -15,12 +16,12 @@ else
 fi
 git rm -rf .
 touch .gitmodules
-git restore -s origin/master docs
+git restore -s origin/${default_branch} docs
 set +e
 git rm -r docs/boilerplate -r
 rm -rf docs/boilerplate
 set -e
-git restore -s origin/master templates
+git restore -s origin/${default_branch} templates
 git submodule add https://github.com/aws-quickstart/quickstart-documentation-base-common.git docs/boilerplate
 rm configure_git_env.sh
 mv docs/images images

--- a/.utils/configure_git_env.sh
+++ b/.utils/configure_git_env.sh
@@ -5,6 +5,7 @@ git fetch
 set +e
 git remote set-head origin --auto
 default_branch=$(basename "$(git symbolic-ref --short refs/remotes/origin/HEAD)")
+doc_commit_id=$(git submodule | grep docs/boilerplate | cut -d - -f 2 | cut -f 1 -d " ")
 git rev-parse --verify origin/gh-pages
 CHECK_BRANCH=$?
 set -e
@@ -24,5 +25,8 @@ rm -rf docs/boilerplate
 set -e
 git restore -s origin/${default_branch} templates
 git submodule add https://github.com/aws-quickstart/quickstart-documentation-base-common.git docs/boilerplate
+cd docs/boilerplate
+git checkout "${doc_commit_id}"
+cd ../../
 rm configure_git_env.sh
 mv docs/images images

--- a/.utils/configure_git_env.sh
+++ b/.utils/configure_git_env.sh
@@ -3,6 +3,7 @@ set -x
 git remote update
 git fetch
 set +e
+git remote set-head origin --auto
 default_branch=$(basename "$(git symbolic-ref --short refs/remotes/origin/HEAD)")
 git rev-parse --verify origin/gh-pages
 CHECK_BRANCH=$?

--- a/.utils/create_repo_structure.sh
+++ b/.utils/create_repo_structure.sh
@@ -18,7 +18,7 @@ rsync -avP ${BOILERPLATE_DIR}/.images/ docs/images/
 rsync -avP ${BOILERPLATE_DIR}/.specific/ ${SPECIFIC_DIR}
 
 # enabling workflow.
-cp ${BOILERPLATE_DIR}/.actions/master-docs-build.yml .github/workflows/
+cp ${BOILERPLATE_DIR}/.actions/main-docs-build.yml .github/workflows/
 
 
 # creating placeholders.

--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -71,8 +71,6 @@ def just_pass():
             parameter_labels[label_name] = label_data.get('default')
 
         for param_name, param_data in template['Parameters'].items():
-            if param_data.get('Default') == '':
-                del param_data['Default']
             parameter_mappings[param_name] = param_data
             if not reverse_label_mappings.get(param_name):
                 no_groups[param_name] = param_data

--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -71,6 +71,8 @@ def just_pass():
             parameter_labels[label_name] = label_data.get('default')
 
         for param_name, param_data in template['Parameters'].items():
+            if param_data.get('Default') == '':
+                param_data['Default'] = '**__Blank string__**'
             parameter_mappings[param_name] = param_data
             if not reverse_label_mappings.get(param_name):
                 no_groups[param_name] = param_data

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-*       @aws-quickstart/aws_quickstart_team/sa
-/.specific/* @aws-quickstart/aws_quickstart_team/tw @aws-quickstart/aws_quickstart_team/sa
+*       @aws-quickstart/sa
+/.specific/* @aws-quickstart/tw @aws-quickstart/sa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @aws-quickstart/aws_quickstart_team/sa
+/.specific/* @aws-quickstart/aws_quickstart_team/tw @aws-quickstart/aws_quickstart_team/sa

--- a/_layout_cfn.adoc
+++ b/_layout_cfn.adoc
@@ -14,7 +14,7 @@ include::../{includedir}/overview.adoc[]
 == {partner-product-name} on AWS
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/product_description.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]
@@ -26,10 +26,11 @@ endif::production_build[]
 == Cost
 include::../{includedir}/cost.adoc[]
 
+ifndef::disable_licenses[]
 == Software licenses
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/licenses.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]
@@ -37,11 +38,12 @@ include::../{specificdir}/licenses.adoc[]
 ifndef::production_build[]
 |===
 endif::production_build[]
+endif::disable_licenses[]
 
 == Architecture
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/architecture.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]
@@ -64,25 +66,25 @@ include::../{includedir}/deployment_steps.adoc[]
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/additional_info.adoc`**_
-[#preview_mode]
-|===
-a|
+++++
+<div class="preview_mode">
+++++
 endif::production_build[]
 include::../{specificdir}/additional_info.adoc[]
-ifndef::production_build[]
-|===
-endif::production_build[]
+
 
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/faq_troubleshooting.adoc`**_
-[#preview_mode]
-|===
-a|
+++++
+<div class="preview_mode">
+++++
 endif::production_build[]
 include::../{specificdir}/faq_troubleshooting.adoc[]
 ifndef::production_build[]
-|===
+++++
+</div>
+++++
 endif::production_build[]
 
 == Send us feedback

--- a/_layout_cfn.adoc
+++ b/_layout_cfn.adoc
@@ -87,6 +87,12 @@ ifndef::production_build[]
 ++++
 endif::production_build[]
 
+ifdef::parameters_as_appendix[]
+== Parameter reference
+
+include::../{generateddir}/parameters/index.adoc[]
+endif::parameters_as_appendix[]
+
 == Send us feedback
 
 To post feedback, submit feature ideas, or report bugs, use the *Issues* section of the https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] for this Quick Start. If you’d like to submit code, please review the https://aws-quickstart.github.io/[Quick Start Contributor’s Guide^].

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -12,21 +12,19 @@ ifndef::production_build[]
 ++++
 endif::production_build[]
 
+ifndef::custom_number_of_deploy_steps[]
 ifndef::parameters_as_appendix[]
 In the following tables, parameters are listed by category and described separately for the deployment options. When you finish reviewing and customizing the parameters, choose *Next*.
 endif::parameters_as_appendix[]
 
-ifndef::custom_number_of_deploy_steps[]
 NOTE: Unless you are customizing the Quick Start templates for your own deployment projects, we recommend that you keep the default settings for the parameters labeled `Quick Start S3 bucket name`, `Quick Start S3 bucket
 Region`, and `Quick Start S3 key prefix`. Changing these parameter settings automatically updates code references to point to a new Quick Start location. For more information, see the https://aws-quickstart.github.io/option1.html[AWS Quick Start Contributor’s Guide^].
-endif::custom_number_of_deploy_steps[]
 
 ifndef::parameters_as_appendix[]
 // Parameter tables linked in here
 include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 
-ifndef::custom_number_of_deploy_steps[]
 [start=5]
 . On the options page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re done, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -1,12 +1,15 @@
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/deploy_steps.adoc`**_
-[#preview_mode]
---
+++++
+<div class="preview_mode">
+++++
 endif::production_build[]
 include::../{specificdir}/deploy_steps.adoc[]
 ifndef::production_build[]
---
+++++
+</div>
+++++
 endif::production_build[]
 
 In the following tables, parameters are listed by category and described separately for the deployment options. When you finish reviewing and customizing the parameters, choose *Next*.
@@ -31,4 +34,3 @@ ifndef::partner-product-short-name[.{partner-product-name} outputs after success
 ifdef::partner-product-short-name[.{partner-product-short-name} outputs after successful deployment]
 [link=images/cfn_outputs.png]
 image::../images/cfn_outputs.png[cfn_outputs,width=648,height=439]
-

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -12,14 +12,21 @@ ifndef::production_build[]
 ++++
 endif::production_build[]
 
+ifndef::parameters_as_appendix[]
 In the following tables, parameters are listed by category and described separately for the deployment options. When you finish reviewing and customizing the parameters, choose *Next*.
+endif::parameters_as_appendix[]
 
+ifndef::custom_number_of_deploy_steps[]
 NOTE: Unless you are customizing the Quick Start templates for your own deployment projects, we recommend that you keep the default settings for the parameters labeled `Quick Start S3 bucket name`, `Quick Start S3 bucket
 Region`, and `Quick Start S3 key prefix`. Changing these parameter settings automatically updates code references to point to a new Quick Start location. For more information, see the https://aws-quickstart.github.io/option1.html[AWS Quick Start Contributor’s Guide^].
+endif::custom_number_of_deploy_steps[]
 
+ifndef::parameters_as_appendix[]
 // Parameter tables linked in here
 include::../{generateddir}/parameters/index.adoc[]
+endif::parameters_as_appendix[]
 
+ifndef::custom_number_of_deploy_steps[]
 [start=5]
 . On the options page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re done, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
@@ -34,3 +41,4 @@ ifndef::partner-product-short-name[.{partner-product-name} outputs after success
 ifdef::partner-product-short-name[.{partner-product-short-name} outputs after successful deployment]
 [link=images/cfn_outputs.png]
 image::../images/cfn_outputs.png[cfn_outputs,width=648,height=439]
+endif::custom_number_of_deploy_steps[]

--- a/disclaimer.adoc
+++ b/disclaimer.adoc
@@ -1,6 +1,6 @@
 © 2020, Amazon Web Services Inc., or its affiliates, and {partner-company-name}. All rights reserved.
 
-==== Notices 
+== Notices
 
 This document is provided for informational purposes only. It represents AWS’s current product offerings and practices as of the date of issue of this document, which are subject to change without notice. Customers are responsible for making their own independent assessment of the information in this document and any use of AWS’s products or services, each of which is provided “as is” without warranty of any kind, whether expressed or implied. This document does not create any warranties, representations, contractual commitments, conditions, or assurances from AWS, its affiliates, suppliers, or licensors. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
 

--- a/introduction.adoc
+++ b/introduction.adoc
@@ -3,14 +3,14 @@
 == Quick Start Reference Deployment
 
 [.text-center]
-image::https://aws-quickstart.s3.amazonaws.com/{quickstart-project-name}/docs/boilerplate/.images/aws-quickstart-graphic.png[QS,80,80]
+image::../images/aws-quickstart-graphic.png[QS,80,80]
 
 ifndef::production_build[]
 [.text-center]
 [discrete]
 === DRAFT DOCUMENT / UNOFFICIAL GUIDANCE
 _**This portion of the deployment guide is located at `docs/{specificdir}/__settings_.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]

--- a/overview.adoc
+++ b/overview.adoc
@@ -2,7 +2,7 @@
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/overview_target_and_usage.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]
@@ -11,6 +11,8 @@ ifndef::production_build[]
 |===
 endif::production_build[]
 
+ifdef::partner-company-name[]
 NOTE: Amazon may share who uses AWS
 Quick Starts with the AWS Partner Network (APN) Partner that
 collaborated with AWS on the content of the Quick Start.
+endif::partner-company-name[]

--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -10,7 +10,7 @@ Cloud.
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/specialized_knowledge.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]
@@ -25,9 +25,11 @@ If you don’t already have an AWS account, create one at https://aws.amazon.com
 
 Your AWS account is automatically signed up for all AWS services. You are charged only for the services you use.
 
+ifndef::disable_requirements[]
 === Technical requirements
 
 Before you launch the Quick Start, your account must be configured as specified in the following table. Otherwise, deployment might fail.
+endif::disable_requirements[]
 
 ==== Resource limits
 // http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[Resources] a|
@@ -36,7 +38,7 @@ If necessary, request https://console.aws.amazon.com/servicequotas/home?region=u
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/service_limits.adoc`**_
 ++++
-<div id="preview_mode">
+<div class="preview_mode">
 ++++
 endif::production_build[]
 include::../{specificdir}/service_limits.adoc[]
@@ -47,6 +49,7 @@ ifndef::production_build[]
 endif::production_build[]
 include::../{generateddir}/services/metadata.adoc[]
 
+ifndef::disable_regions[]
 // We can also pull in regions automatically.
 ==== Supported Regions
 
@@ -78,6 +81,7 @@ endif::auto_populate_regions[]
 
 TIP: Certain Regions are available on an opt-in basis. Refer to the AWS Documentation on https://docs.aws.amazon.com/general/latest/gr/rande-manage.html[Managing Regions^] for more information.
 
+endif::disable_regions[]
 ifdef::template_ec2[]
 ==== EC2 key pairs
 ifndef::production_build[====]
@@ -96,7 +100,7 @@ The _AdministratorAccess_ managed policy within IAM provides sufficient permissi
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/pre-reqs.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]
@@ -108,7 +112,7 @@ endif::production_build[]
 ==== Deployment options
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/deployment_options.adoc`**_
-[id="preview_mode"]
+[.preview_mode]
 |===
 a|
 endif::production_build[]


### PR DESCRIPTION
opened this as a pr for review, but should not be merged, instead the main branch should be set as the default branch for this repo, the current default master can either be deleted, or kept for some time and then deleted.

Current submodules following the docs2.0 guidance should be unaffected by this, as the submodule should not specify a branch, so it will use default. to verify check that there is no branch specified in `.gitmodules` (eg.: https://github.com/aws-quickstart/quickstart-aws-vpc/blob/master/.gitmodules)

I couldn't work out how to enable an arbitrary default branch name because github actions requires a list of branch names in a yaml config file and I could not see a way to pass a dynamic value to that. So instead I've added `main` as a 2nd branch to act on.

Tested on repos with both master and main as the default branch names.

Existing repo's that want to rename their master branch will need to add `- main`  to ``.github/workflows/main-docs-build.yml`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
