### PR TITLE
Docs edit

### DIFF
--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -71,6 +71,8 @@ def just_pass():
             parameter_labels[label_name] = label_data.get('default')
 
         for param_name, param_data in template['Parameters'].items():
+            if param_data.get('Default') == '':
+                param_data['Default'] = '**__Blank string__**'
             parameter_mappings[param_name] = param_data
             if not reverse_label_mappings.get(param_name):
                 no_groups[param_name] = param_data

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -12,21 +12,19 @@ ifndef::production_build[]
 ++++
 endif::production_build[]
 
+ifndef::custom_number_of_deploy_steps[]
 ifndef::parameters_as_appendix[]
 In the following tables, parameters are listed by category and described separately for the deployment options. When you finish reviewing and customizing the parameters, choose *Next*.
 endif::parameters_as_appendix[]
 
-ifndef::custom_number_of_deploy_steps[]
 NOTE: Unless you are customizing the Quick Start templates for your own deployment projects, we recommend that you keep the default settings for the parameters labeled `Quick Start S3 bucket name`, `Quick Start S3 bucket
 Region`, and `Quick Start S3 key prefix`. Changing these parameter settings automatically updates code references to point to a new Quick Start location. For more information, see the https://aws-quickstart.github.io/option1.html[AWS Quick Start Contributor’s Guide^].
-endif::custom_number_of_deploy_steps[]
 
 ifndef::parameters_as_appendix[]
 // Parameter tables linked in here
 include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 
-ifndef::custom_number_of_deploy_steps[]
 [start=5]
 . On the options page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re done, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -25,7 +25,7 @@ ifndef::parameters_as_appendix[]
 include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 
-[start=1]
+[start=5]
 . On the options page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re done, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -25,7 +25,7 @@ ifndef::parameters_as_appendix[]
 include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 
-[start=5]
+[start=1]
 . On the options page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re done, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.

--- a/overview.adoc
+++ b/overview.adoc
@@ -12,7 +12,5 @@ ifndef::production_build[]
 endif::production_build[]
 
 ifdef::partner-company-name[]
-NOTE: Amazon may share who uses AWS
-Quick Starts with the AWS Partner Network (APN) Partner that
-collaborated with AWS on the content of the Quick Start.
+NOTE: Amazon may share user-deployment information with the AWS Partner that collaborated with AWS on the Quick Start.
 endif::partner-company-name[]

--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -33,7 +33,7 @@ endif::disable_requirements[]
 
 ==== Resource limits
 // http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[Resources] a|
-If necessary, request https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[service quota increases^] for the following resources. You might need to request increases if your existing deployment currently uses these resources, and this Quick Start deployment could result in exceeding the default quotas. The https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[Service Quotas console^] displays your usage and quotas for some aspects of some services. For more information, see the https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html[AWS documentation^].
+If necessary, request https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[service quota increases^] for the following resources. You might need to request increases if your existing deployment currently uses these resources, and this Quick Start deployment could result in exceeding the default quotas. The https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[Service Quotas console^] displays your usage and quotas for some aspects of some services. For more information, see https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html[What is Service Quotas?^]
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/service_limits.adoc`**_
@@ -87,7 +87,7 @@ ifdef::template_ec2[]
 ifndef::production_build[====]
 ifndef::production_build[_This section is conditional on EC2 instances being used in the Cloudformation Templates_]
 ifndef::production_build[====]
-Make sure that at least one https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pair^] exists in your AWS account in the Region where you plan to deploy the Quick Start. Make note of the key pair name. You need it during deployment. To create a key pair, follow the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[instructions in the AWS documentation^].
+Make sure that at least one https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pair^] exists in your AWS account in the Region where you plan to deploy the Quick Start. Make note of the key pair name. You need it during deployment. To create a key pair, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pairs and Linux instances^].
 
 For testing or proof-of-concept purposes, we recommend creating a new key pair instead of using one that’s already being used by a production instance.
 endif::template_ec2[]


### PR DESCRIPTION
Updated APN -> AWS Partner language in overview.adoc, and edited link text to read the name of the page it's going to instead of "AWS Documentation". Commit "Update deployment_steps.adoc" should be ignored.