### PR TITLE
Update architecture.adoc

### DIFF
--- a/.specific/architecture.adoc
+++ b/.specific/architecture.adoc
@@ -6,25 +6,21 @@ AWS Cloud.
 [#architecture1]
 .Quick Start architecture for _{partner-product-short-name}_ on AWS
 [link=images/architecture_diagram.png]
-image::../images/architecture_diagram.png[Architecture,width=648,height=439]
+image::../images/architecture_diagram.png[Architecture,width=100%,height=100%]
 
-As shown in Figure 1, the Quick Start sets up the following:
+As shown in <<architecture1>>, the Quick Start sets up the following:
 
 * A highly available architecture that spans two Availability Zones.*
-* A VPC configured with public and private subnets, according to AWS
-best practices, to provide you with your own virtual network on AWS.*
+* A VPC configured with public and private subnets, according to AWS best practices, to provide you with your own virtual network on AWS.*
 
 In the public subnets:
 
-* Managed network address translation (NAT) gateways to allow outbound
-internet access for resources in the private subnets.*
-* A Linux bastion host in an Auto Scaling group to allow inbound Secure
-Shell (SSH) access to EC2 instances in public and private subnets.*
+* Managed network address translation (NAT) gateways to allow outbound internet access for resources in the private subnets.*
+* A Linux bastion host in an Auto Scaling group to allow inbound Secure Shell (SSH) access to EC2 instances in public and private subnets.*
 
 In the private subnets:
 // Add bullet points for any additional components that are included in the deployment. Make sure that the additional components are also represented in the architecture diagram.
 * <describe any additional components>.
 
-*The template that deploys the Quick Start into an existing VPC skips
-the components marked by asterisks and prompts you for your existing VPC
-configuration.
+[.small]*The template that deploys the Quick Start into an existing VPC skips the components marked by asterisks and prompts you for your existing VPC
+configuration.#


### PR DESCRIPTION
- Swapped in a `<<pointer to the figure>>` instead of " As shown in Figure 1" since this figure isn't always #1.
- Made the footnote smaller type.
- Made the architecture diagram dimensions 100% x 100% instead of specific height and width.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
