### PR TITLE
Quick Start icon in the deployment guide should come from aws-quickstart bucket

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -2,6 +2,7 @@
 [discrete]
 == Quick Start Reference Deployment
 
+# Do not change the URL below. The aws-quickstart-graphic.png icon needs to come from the aws-quickstart S3 bucket.
 [.text-center]
 image::https://aws-quickstart.s3.amazonaws.com/{quickstart-project-name}/docs/boilerplate/.images/aws-quickstart-graphic.png[QS,80,80]
 

--- a/introduction.adoc
+++ b/introduction.adoc
@@ -3,7 +3,7 @@
 == Quick Start Reference Deployment
 
 [.text-center]
-image::../images/aws-quickstart-graphic.png[QS,80,80]
+image::https://aws-quickstart.s3.amazonaws.com/{quickstart-project-name}/docs/boilerplate/.images/aws-quickstart-graphic.png[QS,80,80]
 
 ifndef::production_build[]
 [.text-center]


### PR DESCRIPTION
*Description of changes:*
Quick Start icon in the deployment guide should come from aws-quickstart bucket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
