### PR TITLE
Removing templates from gh-pages branch

### DIFF
--- a/.utils/commit_and_push_to_ghpages.sh
+++ b/.utils/commit_and_push_to_ghpages.sh
@@ -14,6 +14,7 @@ git config --local user.name "GitHub Action"
 git add -A
 git add images
 git add index.html
+git rm -r templates
 git commit -a -m "Updating documentation"
 if [ $? -ne 0 ]; then
     echo "nothing to commit"


### PR DESCRIPTION
Github attempts to 'lint' the content of `templates/` prior to the Github pages build, leading to false-positive errors. 

Ex: `The variable {{resolve:ssm:/${AOCStackPrefix} on line 159 in templates/amis/create-amis.yaml was not properly closed with }}.`

https://github.com/aws-quickstart/quickstart-aem-opencloud/runs/1188314982

This PR removes `templates` from the directory tree just prior to pushing to the `gh-pages` branch, allowing dynamic content, but preventing said issues.
