### PR TITLE
must force because files are already staged in the index

### DIFF
--- a/.utils/commit_and_push_to_ghpages.sh
+++ b/.utils/commit_and_push_to_ghpages.sh
@@ -14,7 +14,7 @@ git config --local user.name "GitHub Action"
 git add -A
 git add images
 git add index.html
-git rm -r templates
+git rm -r --force templates
 git commit -a -m "Updating documentation"
 if [ $? -ne 0 ]; then
     echo "nothing to commit"


### PR DESCRIPTION
#69 introduced a bug where builds in github actions will fail with the error:

```
Run ./docs/boilerplate/.utils/commit_and_push_to_ghpages.sh
error: the following files have changes staged in the index:
    templates/<template-name>
    ...
(use --cached to keep the file, or -f to force removal)
Error: Process completed with exit code 1.
```

This addresses the issue.

tested [here](https://github.com/jaymccon/quickstart-amazon-eks/runs/1189265513?check_suite_focus=true)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
