### PR TITLE
only add partner name to footer if defined

### DIFF
--- a/index-docinfo-footer.html
+++ b/index-docinfo-footer.html
@@ -1,5 +1,5 @@
 <p class="footer-text">
 <!-- We can use document attributes: -->
 <!-- Generated with Asciidoctor v{asciidoctor-version}. -->
-<a href="https://aws.amazon.com/privacy/">Privacy</a> | <a href="https://aws.amazon.com/terms/">Site terms</a> | &copy; 2020, Amazon Web Services, Inc. or its affiliates and {partner-company-name}. All rights reserved.
+<a href="https://aws.amazon.com/privacy/">Privacy</a> | <a href="https://aws.amazon.com/terms/">Site terms</a> | &copy; 2020, Amazon Web Services, Inc. or its affiliates{partner-company-footer}. All rights reserved.
 </p>

--- a/index.adoc
+++ b/index.adoc
@@ -9,9 +9,16 @@
 :stylesheet: {includedir}/.css/quickstart.css
 :project_cfn:
 :template_services_ec2:
+include::{specificdir}/_settings.adoc[]
+
+// the next two lines are needed for quickstarts that are not built with a partner, if removed, footer text is mangled for those quickstarts. They must be below _settings.adoc
+ifdef::partner-company-name[:partner-company-footer: {sp}and {partner-company-name}]
+ifndef::partner-company-name[:partner-company-footer:]
+
+// the next 3 lines must remain below partner-company-footer definitions
 :nofooter:
 :docinfodir: boilerplate
 :docinfo:
-include::{specificdir}/_settings.adoc[]
+
 :title: {partner-product-name} on the AWS Cloud
 ifdef::project_cfn[include::{includedir}/_layout_cfn.adoc[]]


### PR DESCRIPTION
*Issue #, if available:* #71

Footer text is able to resolve adoc attributes (variables) but cannot process complex directives like `ifdef::`. So for quick start's that do not have a partner, and as such don't have `partner-company-name` defined, end up with a footer that contains the variable name instead:

```
© 2020, Amazon Web Services, Inc. or its affiliates and {partner-company-name}. All rights reserved.
```

this fixes that by rendering a `partner-company-footer` attribute tht conditionally is either blank or contains the needed part of the footer text.

cc: @sshvans for visibility

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
