### PR TITLE
only push if there are commits to push

### DIFF
--- a/.utils/commit_and_push_to_ghpages.sh
+++ b/.utils/commit_and_push_to_ghpages.sh
@@ -22,4 +22,4 @@ if [ $? -ne 0 ]; then
 fi
 
 git remote set-url origin ${repo_uri}
-git push origin HEAD:${target_branch} --force
+git status | grep "nothing to commit, working tree clean" || git push origin HEAD:${target_branch} --force


### PR DESCRIPTION
Builds that contain no docs changes are failing currently. See https://github.com/aws-quickstart/quickstart-eks-snyk/runs/1222946875?check_suite_focus=true 

```
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

This fixes that by skipping commit if `git status` response contains `nothing to commit, working tree clean`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Closes #2