### PR TITLE
fix faulty push logic

### DIFF
--- a/.utils/commit_and_push_to_ghpages.sh
+++ b/.utils/commit_and_push_to_ghpages.sh
@@ -22,4 +22,4 @@ if [ $? -ne 0 ]; then
 fi
 
 git remote set-url origin ${repo_uri}
-git status | grep "nothing to commit, working tree clean" || git push origin HEAD:${target_branch} --force
+git status | grep "Your branch is up to date" || git push origin HEAD:${target_branch} --force


### PR DESCRIPTION
Logic in previous pr was faulty. The git status output for a clean tree, with commits that need to be pushed will include the string `nothing to commit, working tree clean`. Instead we should look for the part that tells whether we're up to date with the remote.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
