### PR TITLE
Moved parameter tables to an appendix & added a cross-ref

### DIFF
--- a/.specific/_settings.adoc
+++ b/.specific/_settings.adoc
@@ -21,6 +21,7 @@
 // for example, 1.25 hours, 2 hours, 2.5 hours.
 :deployment_time: 15 minutes / 60 minutes / 1.5 hours
 :default_deployment_region: us-east-1
+:parameters_as_appendix:
 // Uncomment the following two attributes if you are using an AWS Marketplace listing.
 // Additional content will be generated automatically based on these attributes.
 // :marketplace_subscription:

--- a/.specific/deploy_steps.adoc
+++ b/.specific/deploy_steps.adoc
@@ -46,9 +46,4 @@ Each deployment takes about {deployment_time} to complete.
 
 [start=3]
 . On the *Create stack* page, keep the default setting for the template URL, and then choose *Next*.
-. On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For all other parameters, review the default settings and customize them as necessary.
-
-// In the following tables, parameters are listed by category and described separately for the two deployment options:
-
-// * Parameters for deploying {partner-product-short-name} into a new VPC
-// * Parameters for deploying {partner-product-short-name} into an existing VPC
+. On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For details on each parameter, see the link:#_parameter_reference[Parameter reference] section of this guide.


### PR DESCRIPTION
Added :parameters_as_appendix:

Addresses part of *[Issue #48](https://github.com/aws-quickstart/quickstart-documentation-base-common/issues/48) by moving parameter tables into an appendix.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
