### PR TITLE
Updating cfn-lint behavior, version

### DIFF
--- a/.utils/generate_metadata_attributes.py
+++ b/.utils/generate_metadata_attributes.py
@@ -3,9 +3,11 @@ import io
 import cfnlint
 from pathlib import Path
 
-
 def get_cfn(filename):
-    _decoded = cfnlint.decode.decode(filename, False)[0]
+    _decoded, _issues = cfnlint.decode.decode(filename)
+    if not _decoded:
+        print(f"Template: {filename} has an error. Run cfn-lint to determine the issue")
+        sys.exit(1)
     return _decoded
 
 def fetch_metadata():

--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -2,11 +2,15 @@
 import io
 import cfnlint
 import datetime
+import sys
 from pathlib import Path
 
 
 def get_cfn(filename):
-    _decoded = cfnlint.decode.decode(filename, False)[0]
+    _decoded, _issues = cfnlint.decode.decode(filename)
+    if not _decoded:
+        print(f"Template: {filename} has an error. Run cfn-lint to determine the issue")
+        sys.exit(1)
     return _decoded
 
 def _generate_table_name_and_header(label_name):

--- a/.utils/requirements.txt
+++ b/.utils/requirements.txt
@@ -1,5 +1,5 @@
 requests
-cfn-lint
+cfn-lint >= 0.39.0
 pathlib
 datetime
 ruamel.yaml


### PR DESCRIPTION
cfn-lint v 0.39.0 introduced a breaking change in the cfnlint.decode.decode method. This PR modifies our dynamic content generation scripts to reflect this change. Tested against a QS, both valid and non-valid template codepaths.