### PR TITLE
Adding support for a Second Language doc and link

### DIFF
--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -12,3 +12,13 @@ if [ "${GITHUB_REPO_OWNER}" == "aws-quickstart" ]; then
   fi
 fi
 asciidoctor --base-dir docs/ --backend=html5 -o ../index.html -w --failure-level ERROR --doctype=book -a toc2 ${ASCIIDOC_ATTRIBUTES} docs/boilerplate/index.adoc
+
+
+if [ -d docs/languages ]; then
+  for dir in docs/languages/*/
+  do
+    dir=${dir%*/}
+    lang=$(echo ${dir%*/} | awk -F'[-]' '{print $2}')
+    asciidoctor --base-dir docs/languages/docs-${lang}/ --backend=html5 -o ../../../index-${lang}.html -w --failure-level ERROR --doctype=book -a toc2 ${ASCIIDOC_ATTRIBUTES} docs/languages/docs-${lang}/index.adoc
+  done
+fi

--- a/.utils/create_repo_structure.sh
+++ b/.utils/create_repo_structure.sh
@@ -59,6 +59,7 @@ create_repo
 LANG_DIR="docs/languages"
 SPECIFIC_LANG_DIR="docs/languages/docs-${LANG_CODE}"
 TRANSLATE_ONLY="docs/languages/docs-${LANG_CODE}/translate-only"
+LANG_FOLDER="docs-${LANG_CODE}"
 mkdir -p ${LANG_DIR}
 mkdir -p ${SPECIFIC_LANG_DIR}
 mkdir -p ${TRANSLATE_ONLY}
@@ -69,7 +70,7 @@ rsync -avP ${BOILERPLATE_DIR}/index.lang.adoc ${SPECIFIC_LANG_DIR}/index.adoc
 rsync -avP ${BOILERPLATE_DIR}/planning_deployment.lang.adoc ${TRANSLATE_ONLY}/planning_deployment.adoc
 rsync -avP ${BOILERPLATE_DIR}/index-docinfo-footer.html ${TRANSLATE_ONLY}
 rsync -avP ${BOILERPLATE_DIR}/LICENSE ${TRANSLATE_ONLY}
-sed -i "" "s/docs-lang-code/docs-${LANG_CODE}/g" ${SPECIFIC_LANG_DIR}/index.adoc
+sed -i "" "s/docs-lang-code/${LANG_FOLDER}/g" ${SPECIFIC_LANG_DIR}/index.adoc
 }
 
 while true

--- a/.utils/create_repo_structure.sh
+++ b/.utils/create_repo_structure.sh
@@ -2,6 +2,30 @@
 # # Work in progress.
 # exit 1
 
+#Adds Help and Second Language options (-h | -l)
+while getopts hl  option
+do
+    case "${option}" in
+      h )
+          echo "Usage:"
+          echo "Run './create_repo_structure.sh' with no options for English langauge only."
+          echo "Run './create_repo_structure.sh -l' to add files for second langauge."
+          echo " "
+          echo "(-h)       Show usage and brief help"
+          echo "(-l)       Use to add files for second language for translation"
+          exit 0
+          ;;
+      l )
+          CREATESECONDLANG="create_second_lang";;
+      * )
+          echo "this is in an invalid flag. Please see "-h" for help on valid flags"
+          exit 0
+          ;;
+    esac
+done
+
+#Creates Standard English directory structure to the repo.
+function create_repo() {
 BOILERPLATE_DIR="docs/boilerplate"
 GENERATED_DIR="docs/generated"
 SPECIFIC_DIR="docs/partner_editable"
@@ -26,9 +50,38 @@ echo "// placeholder" > ${GENERATED_DIR}/parameters/index.adoc
 echo "// placeholder" > ${GENERATED_DIR}/regions/index.adoc
 echo "// placeholder" > ${GENERATED_DIR}/services/index.adoc
 echo "// placeholder" > ${GENERATED_DIR}/services/metadata.adoc
+}
 
+#Creates standard English and second language directory structures to the repo.
+function create_second_lang() {
+read -p "Please enter enter 2 character language code: " LANG_CODE
+create_repo
+LANG_DIR="docs/languages"
+SPECIFIC_LANG_DIR="docs/languages/docs-${LANG_CODE}"
+TRANSLATE_ONLY="docs/languages/docs-${LANG_CODE}/translate-only"
+mkdir -p ${LANG_DIR}
+mkdir -p ${SPECIFIC_LANG_DIR}
+mkdir -p ${TRANSLATE_ONLY}
+rsync -avP ${BOILERPLATE_DIR}/.specific/ ${SPECIFIC_LANG_DIR}/partner_editable
+rsync -avP ${BOILERPLATE_DIR}/*.adoc ${TRANSLATE_ONLY} --exclude *.lang.adoc --exclude index.adoc --exclude _layout_cfn.adoc --exclude planning_deployment.adoc
+rsync -avP ${BOILERPLATE_DIR}/_layout_cfn.lang.adoc ${SPECIFIC_LANG_DIR}/_layout_cfn.adoc
+rsync -avP ${BOILERPLATE_DIR}/index.lang.adoc ${SPECIFIC_LANG_DIR}/index.adoc
+rsync -avP ${BOILERPLATE_DIR}/planning_deployment.lang.adoc ${TRANSLATE_ONLY}/planning_deployment.adoc
+rsync -avP ${BOILERPLATE_DIR}/index-docinfo-footer.html ${TRANSLATE_ONLY}
+rsync -avP ${BOILERPLATE_DIR}/LICENSE ${TRANSLATE_ONLY}
+sed -i "" "s/docs-lang-code/docs-${LANG_CODE}/g" ${SPECIFIC_LANG_DIR}/index.adoc
+}
+
+while true
+do
+#clear
+if [ $OPTIND -eq 1 ]; then create_repo; fi
+shift $((OPTIND-1))
+#printf "$# non-option arguments"
+$CREATESECONDLANG
 touch .nojekyll
-
 git add -A docs/
 git add .github/
 git add .nojekyll
+exit
+done

--- a/_layout_cfn.lang.adoc
+++ b/_layout_cfn.lang.adoc
@@ -1,0 +1,114 @@
+
+[.text-center]
+[discrete]
+== {partner-product-name} on the AWS Cloud
+:doctitle: {partner-product-name} on the AWS Cloud
+:!toc:
+[.text-left]
+include::translate-only/introduction.adoc[]
+
+== Overview
+include::translate-only/overview.adoc[]
+
+
+== {partner-product-name} on AWS
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/product_description.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::{specificdir}/product_description.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+== Cost
+include::translate-only/cost.adoc[]
+
+ifndef::disable_licenses[]
+== Software licenses
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/licenses.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::{specificdir}/licenses.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+endif::disable_licenses[]
+
+== Architecture
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/architecture.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::{specificdir}/architecture.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+== Planning the deployment
+include::translate-only/planning_deployment.adoc[]
+
+== Deployment steps
+include::translate-only/deployment_steps.adoc[]
+
+// == Parameters
+// include::../{generateddir}/parameters/index.adoc[]
+
+// additional_info.adoc contains 3 sections: Best Practice, Security & Other information
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/additional_info.adoc`**_
+++++
+<div class="preview_mode">
+++++
+endif::production_build[]
+include::{specificdir}/additional_info.adoc[]
+
+
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/faq_troubleshooting.adoc`**_
+++++
+<div class="preview_mode">
+++++
+endif::production_build[]
+include::{specificdir}/faq_troubleshooting.adoc[]
+ifndef::production_build[]
+++++
+</div>
+++++
+endif::production_build[]
+
+ifdef::parameters_as_appendix[]
+== Parameter reference
+
+NOTE: Unless you are customizing the Quick Start templates for your own deployment projects, we recommend that you keep the default settings for the parameters labeled `Quick Start S3 bucket name`, `Quick Start S3 bucket
+Region`, and `Quick Start S3 key prefix`. Changing these parameter settings automatically updates code references to point to a new Quick Start location. For more information, see the https://aws-quickstart.github.io/option1.html[AWS Quick Start Contributor’s Guide^].
+
+include::../../{generateddir}/parameters/index.adoc[]
+endif::parameters_as_appendix[]
+
+== Send us feedback
+
+To post feedback, submit feature ideas, or report bugs, use the *Issues* section of the https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] for this Quick Start. To submit code, see the https://aws-quickstart.github.io/[Quick Start Contributor’s Guide^].
+
+== Quick Start reference deployments
+
+See the https://aws.amazon.com/quickstart/[AWS Quick Start home page].
+
+
+== GitHub repository
+
+Visit our https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] to download
+the templates and scripts for this Quick Start, to post your comments,
+and to share your customizations with others.
+
+'''
+include::translate-only/disclaimer.adoc[]

--- a/_layout_cfn.lang.adoc
+++ b/_layout_cfn.lang.adoc
@@ -13,7 +13,7 @@ include::translate-only/overview.adoc[]
 
 == {partner-product-name} on AWS
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/{specificdir}/product_description.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/product_description.adoc`**_
 [.preview_mode]
 |===
 a|
@@ -29,7 +29,7 @@ include::translate-only/cost.adoc[]
 ifndef::disable_licenses[]
 == Software licenses
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/{specificdir}/licenses.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/licenses.adoc`**_
 [.preview_mode]
 |===
 a|
@@ -42,7 +42,7 @@ endif::disable_licenses[]
 
 == Architecture
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/{specificdir}/architecture.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/architecture.adoc`**_
 [.preview_mode]
 |===
 a|
@@ -64,7 +64,7 @@ include::translate-only/deployment_steps.adoc[]
 // additional_info.adoc contains 3 sections: Best Practice, Security & Other information
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/{specificdir}/additional_info.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/additional_info.adoc`**_
 ++++
 <div class="preview_mode">
 ++++
@@ -74,7 +74,7 @@ include::{specificdir}/additional_info.adoc[]
 
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/{specificdir}/faq_troubleshooting.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/faq_troubleshooting.adoc`**_
 ++++
 <div class="preview_mode">
 ++++

--- a/index.lang.adoc
+++ b/index.lang.adoc
@@ -2,8 +2,7 @@
 :includedir: boilerplate
 :specificdir: partner_editable
 :generateddir: generated
-:langdir: languages/docs-lang-code
-:langcode: docs-lang-code
+:langdir: docs-lang-code
 :icons: font
 :toc2: left
 :toc-title: 

--- a/index.lang.adoc
+++ b/index.lang.adoc
@@ -23,4 +23,4 @@ ifndef::partner-company-name[:partner-company-footer:]
 :docinfo:
 
 :title: {partner-product-name} on the AWS Cloud
-ifdef::project_cfn[include::${langdir}/docs_layout_cfn.adoc[]]
+ifdef::project_cfn[include::_layout_cfn.adoc[]]

--- a/index.lang.adoc
+++ b/index.lang.adoc
@@ -1,0 +1,25 @@
+:imagesdir: images
+:includedir: boilerplate
+:specificdir: partner_editable
+:generateddir: generated
+:langdir: docs-lang-code
+:icons: font
+:toc2: left
+:toc-title: 
+:toclevels: 2
+:stylesheet: ../../docs/{includedir}/.css/quickstart.css
+:project_cfn:
+:template_services_ec2:
+include::{specificdir}/_settings.adoc[]
+
+// the next two lines are needed for quickstarts that are not built with a partner, if removed, footer text is mangled for those quickstarts. They must be below _settings.adoc
+ifdef::partner-company-name[:partner-company-footer: {sp}and {partner-company-name}]
+ifndef::partner-company-name[:partner-company-footer:]
+
+// the next 3 lines must remain below partner-company-footer definitions
+:nofooter:
+:docinfodir: boilerplate
+:docinfo:
+
+:title: {partner-product-name} on the AWS Cloud
+ifdef::project_cfn[include::${langdir}/docs_layout_cfn.adoc[]]

--- a/index.lang.adoc
+++ b/index.lang.adoc
@@ -2,12 +2,13 @@
 :includedir: boilerplate
 :specificdir: partner_editable
 :generateddir: generated
-:langdir: docs-lang-code
+:langdir: languages/docs-lang-code
+:langcode: docs-lang-code
 :icons: font
 :toc2: left
 :toc-title: 
 :toclevels: 2
-:stylesheet: ../../docs/{includedir}/.css/quickstart.css
+:stylesheet: ../../{includedir}/.css/quickstart.css
 :project_cfn:
 :template_services_ec2:
 include::{specificdir}/_settings.adoc[]

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -1,0 +1,114 @@
+=== Specialized knowledge
+
+This deployment requires a moderate level of familiarity with AWS services. If you’re new to AWS, visit https://aws.amazon.com/getting-started/[Getting Started with AWS^] and https://aws.amazon.com/training/[Training and Certification^]. These sites provide materials for learning how to design, deploy, and operate your infrastructure and applications on the AWS Cloud.
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/specialized_knowledge.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/specialized_knowledge.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+=== AWS account
+
+If you don’t already have an AWS account, create one at https://aws.amazon.com/[https://aws.amazon.com^] by following the on-screen instructions. Part of the sign-up process involves receiving a phone call and entering a PIN using the phone keypad.
+
+Your AWS account is automatically signed up for all AWS services. You are charged only for the services you use.
+
+ifndef::disable_requirements[]
+=== Technical requirements
+
+Before you launch the Quick Start, your account must be configured as specified in the following table. Otherwise, deployment might fail.
+endif::disable_requirements[]
+
+==== Resource quotas
+If necessary, request https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[service quota increases^] for the following resources. You might need to request increases if your existing deployment currently uses these resources and if this Quick Start deployment could result in exceeding the default quotas. The https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[Service Quotas console^] displays your usage and quotas for some aspects of some services. For more information, see https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html[What is Service Quotas?^] and https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[AWS service quotas^].
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/service_limits.adoc`**_
+++++
+<div class="preview_mode">
+++++
+endif::production_build[]
+include::../{specificdir}/service_limits.adoc[]
+ifndef::production_build[]
+++++
+</div>
+++++
+endif::production_build[]
+include::../../../{generateddir}/services/metadata.adoc[]
+
+ifndef::disable_regions[]
+// We can also pull in Regions automatically.
+==== Supported Regions
+
+ifdef::template_not_all_regions[]
+This deployment includes <service>, which isn’t currently supported in https://aws.amazon.com/about-aws/global-infrastructure/[all AWS Regions^].
+endif::template_not_all_regions[]
+
+ifdef::auto_populate_regions[]
+The following Regions are currently supported by this Quick Start.
+include::../{generateddir}/regions/index.adoc[]
+endif::auto_populate_regions[]
+
+ifndef::auto_populate_regions[]
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/regions.adoc`**_
+++++
+<div id="preview_mode">
+++++
+endif::production_build[]
+include::../{specificdir}/regions.adoc[]
+ifndef::production_build[]
+++++
+</div>
+++++
+endif::production_build[]
+
+endif::auto_populate_regions[]
+
+TIP: Certain Regions are available on an opt-in basis. See https://docs.aws.amazon.com/general/latest/gr/rande-manage.html[Managing AWS Regions^].
+
+endif::disable_regions[]
+ifdef::template_ec2[]
+==== EC2 key pairs
+ifndef::production_build[====]
+ifndef::production_build[_This section applies only if the Cloudformation templates include EC2 instances._]
+ifndef::production_build[====]
+Make sure that at least one https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pair^] exists in your AWS account in the Region where you plan to deploy the Quick Start. Make note of the key pair name. You need it during deployment. To create a key pair, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pairs and Linux instances^].
+
+For testing or proof-of-concept purposes, we recommend creating a new key pair instead of using one that’s already being used by a production instance.
+endif::template_ec2[]
+
+==== IAM permissions
+//todo: scope of least-privilege
+Before launching the Quick Start, you must sign in to the AWS Management Console with IAM permissions for the resources that the templates deploy. The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions. For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[AWS managed policies for job functions^].
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/pre-reqs.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/pre-reqs.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+==== Deployment options
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `_**This portion of the deployment guide is located at `docs/languages/docs-{LANG_CODE}/{specificdir}/pre-reqs.adoc`**_
+/{specificdir}/deployment_options.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/deployment_options.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -3,7 +3,7 @@
 This deployment requires a moderate level of familiarity with AWS services. If you’re new to AWS, visit https://aws.amazon.com/getting-started/[Getting Started with AWS^] and https://aws.amazon.com/training/[Training and Certification^]. These sites provide materials for learning how to design, deploy, and operate your infrastructure and applications on the AWS Cloud.
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/specialized_knowledge.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/specialized_knowledge.adoc`**_
 [.preview_mode]
 |===
 a|
@@ -29,7 +29,7 @@ endif::disable_requirements[]
 If necessary, request https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[service quota increases^] for the following resources. You might need to request increases if your existing deployment currently uses these resources and if this Quick Start deployment could result in exceeding the default quotas. The https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[Service Quotas console^] displays your usage and quotas for some aspects of some services. For more information, see https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html[What is Service Quotas?^] and https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[AWS service quotas^].
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/service_limits.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/service_limits.adoc`**_
 ++++
 <div class="preview_mode">
 ++++
@@ -58,7 +58,7 @@ endif::auto_populate_regions[]
 ifndef::auto_populate_regions[]
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/regions.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/regions.adoc`**_
 ++++
 <div id="preview_mode">
 ++++
@@ -90,7 +90,7 @@ endif::template_ec2[]
 Before launching the Quick Start, you must sign in to the AWS Management Console with IAM permissions for the resources that the templates deploy. The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions. For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[AWS managed policies for job functions^].
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/pre-reqs.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/pre-reqs.adoc`**_
 [.preview_mode]
 |===
 a|

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -3,7 +3,7 @@
 This deployment requires a moderate level of familiarity with AWS services. If you’re new to AWS, visit https://aws.amazon.com/getting-started/[Getting Started with AWS^] and https://aws.amazon.com/training/[Training and Certification^]. These sites provide materials for learning how to design, deploy, and operate your infrastructure and applications on the AWS Cloud.
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/specialized_knowledge.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/specialized_knowledge.adoc`**_
 [.preview_mode]
 |===
 a|
@@ -29,7 +29,7 @@ endif::disable_requirements[]
 If necessary, request https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[service quota increases^] for the following resources. You might need to request increases if your existing deployment currently uses these resources and if this Quick Start deployment could result in exceeding the default quotas. The https://console.aws.amazon.com/servicequotas/home?region=us-east-2#!/[Service Quotas console^] displays your usage and quotas for some aspects of some services. For more information, see https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html[What is Service Quotas?^] and https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[AWS service quotas^].
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/service_limits.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/service_limits.adoc`**_
 ++++
 <div class="preview_mode">
 ++++
@@ -58,7 +58,7 @@ endif::auto_populate_regions[]
 ifndef::auto_populate_regions[]
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/regions.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/regions.adoc`**_
 ++++
 <div id="preview_mode">
 ++++
@@ -90,7 +90,7 @@ endif::template_ec2[]
 Before launching the Quick Start, you must sign in to the AWS Management Console with IAM permissions for the resources that the templates deploy. The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions. For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[AWS managed policies for job functions^].
 
 ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langcode}/{specificdir}/pre-reqs.adoc`**_
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/pre-reqs.adoc`**_
 [.preview_mode]
 |===
 a|


### PR DESCRIPTION
*Description of changes: Added the required scripts and files to generate a second link for a second language. Translation and upkeep at this point are manual. But it is a way to maintain the second language in GIT. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
