### PR TITLE
Adding default value for var introspected in Github Actions

### DIFF
--- a/.utils/commit_and_push_to_ghpages.sh
+++ b/.utils/commit_and_push_to_ghpages.sh
@@ -29,7 +29,7 @@ function github_actions_prod(){
 #    exit 0
 #fi
 
-if [ "${DOCBUILD_PROD}" == "true" ]; then
+if [ "${DOCBUILD_PROD:-x}" == "true" ]; then
   common_steps
 else
   github_actions_prod


### PR DESCRIPTION
PR #101 introduced a bug in the Github Actions components. Github Actions uses `-u` in bash, which bails if a variable is not defined. 

This PR adds a default variable for the DOCBUILD_PROD env var in the script that pushes content to the `gh-pages` branch.