### PR TITLE
add support for eks addin quick starts

### DIFF
--- a/_layout_cfn_eks_module.adoc
+++ b/_layout_cfn_eks_module.adoc
@@ -1,0 +1,108 @@
+:parameters_as_appendix:
+[.text-center]
+[discrete]
+== {partner-product-name}
+:doctitle: {partner-product-name}
+:!toc:
+[.text-left]
+include::../{includedir}/introduction.adoc[]
+
+== Overview
+include::../{includedir}/overview.adoc[]
+
+ifndef::disable_licenses[]
+== Software licenses
+ifndef::production_build[]
+_**This portion of the deployment guide is located in `docs/{specificdir}/licenses.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/licenses.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+endif::disable_licenses[]
+
+== Architecture
+Deploying this Quick Start with default parameters into an existing Amazon EKS cluster builds the following environment. For a diagram of the new virtual private cloud (VPC) and Amazon EKS cluster, see https://aws-quickstart.github.io/quickstart-amazon-eks/[Amazon EKS on the AWS Cloud^].
+
+[#architecture1]
+.Quick Start architecture for _{partner-product-name}_
+[link=images/architecture_diagram.png]
+image::../images/architecture_diagram.png[Architecture]
+
+As shown in Figure 1, the Quick Start sets up the following:
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located in `docs/{specificdir}/architecture.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/architecture.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+== Planning the deployment
+
+include::../{includedir}/planning_deployment_eks_module.adoc[]
+
+== Deployment steps
+include::../{includedir}/deployment_steps_eks_module.adoc[]
+
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located in `docs/{specificdir}/additional_info.adoc`**_
+++++
+<div class="preview_mode">
+++++
+endif::production_build[]
+include::../{specificdir}/additional_info.adoc[]
+
+
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located in `docs/{specificdir}/faq_troubleshooting.adoc`**_
+++++
+<div class="preview_mode">
+++++
+endif::production_build[]
+include::../{specificdir}/faq_troubleshooting.adoc[]
+ifndef::production_build[]
+++++
+</div>
+++++
+endif::production_build[]
+
+== Parameter reference
+
+=== Deploy into a new VPC and new Amazon EKS cluster
+
+The full list of parameters for this entrypoint are documented in https://aws-quickstart.github.io/quickstart-amazon-eks/#_launch_into_a_new_vpc[Amazon EKS on the AWS Cloud^].
+
+
+=== Deploy into a new Amazon EKS cluster in an existing VPC
+
+The full list of parameters for this entrypoint are documented in https://aws-quickstart.github.io/quickstart-amazon-eks/#_launch_into_an_existing_vpc[Amazon EKS on the AWS Cloud^].
+
+include::../{generateddir}/parameters/index.adoc[]
+
+== Send us feedback
+
+To post feedback, submit feature ideas, or report bugs, use the *Issues* section of the https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] for this Quick Start. If you want to submit code, review the https://aws-quickstart.github.io/[Quick Start Contributor’s Guide^].
+
+== Quick Start reference deployments
+
+See the https://aws.amazon.com/quickstart/[AWS Quick Start home page^].
+
+
+== GitHub repository
+
+See the https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] to download
+the templates and scripts for this Quick Start, post comments,
+and share customizations with others.
+
+'''
+include::../{includedir}/disclaimer.adoc[]

--- a/deployment_steps_eks_module.adoc
+++ b/deployment_steps_eks_module.adoc
@@ -1,0 +1,61 @@
+=== Prepare an existing EKS cluster
+NOTE: This step is only required if you launch this Quick Start into an existing Amazon EKS cluster that was not created using the https://aws-quickstart.github.io/quickstart-amazon-eks/[Amazon EKS on the AWS Cloud^] deployment. If you want to create a new EKS cluster with your deployment, skip to step 3.
+
+. Sign in to your AWS account at https://aws.amazon.com[https://aws.amazon.com^] with an IAM user role that has the necessary permissions. For details, see link:#_planning_the_deployment[Planning the deployment], earlier in this guide.
+. Launch the https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/template?stackName=Amazon-EKS&templateURL=https://aws-quickstart.s3.us-east-1.amazonaws.com/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-cluster.template.yaml[cluster preparation template^].
+. The template launches in the US East (Ohio) Region by default. To change the Region, choose another Region from the list in the upper-right corner of the navigation bar.
+. On the *Create stack* page, keep the default setting for the template URL, and then choose *Next*.
+. On the *Specify stack details* page, change the stack name if needed. Enter the name of the Amazon EKS cluster you want to deploy to in addition to the subnet IDs and security group ID associated with the cluster. These can be obtained from the EKS cluster console.
+. On the *Options* page, specify the key-value pairs for resources in your stack, and set advanced options. When you’re done, choose *Next*.
+. On the *Review* page, review and confirm your template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
+. Choose *Create stack* to deploy the stack.
+. Monitor the stack's status until it is *CREATE_COMPLETE*.
+. From the *Outputs* section of the stack, note the `KubernetesRoleArn` and `HelmRoleArn` roles.
+. Add the roles to the `aws-auth config` map in your cluster, specifying `system:masters` for the groups. This allows the Quick Start to manage your cluster via AWS CloudFormation. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html[Managing users or IAM roles for your cluster^].
+
+NOTE: Unless you are customizing the Quick Start templates for your own deployment projects, we recommend that you keep the default settings for the parameters labeled `Quick Start S3 bucket name`, `Quick Start S3 bucket
+Region`, and `Quick Start S3 key prefix`. Changing these parameter settings automatically updates code references to point to a new Quick Start location. For more information, see the https://aws-quickstart.github.io/option1.html[AWS Quick Start Contributor’s Guide^].
+
+include::../{specificdir}/pre-launch-steps.adoc[]
+
+
+=== Launch the Quick Start
+
+NOTE: You are responsible for the cost of the AWS services used while running this Quick Start reference deployment. There is no additional cost for using this Quick Start. For full details, see the pricing pages for each AWS service used by this Quick Start. Prices are subject to change.
+
+. Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see the link:#_deployment_options[Deployment options] section, earlier in this guide.
+
+[cols=3*]
+|===
+^|{launch_new_vpc}[Deploy into a new VPC and new Amazon EKS cluster^]
+^|{launch_existing_vpc}[Deploy into a new Amazon EKS cluster in an existing VPC^]
+^|{launch_existing_cluster}[Deploy into an existing Amazon EKS cluster^]
+
+^|{template_new_vpc}[View template^]
+^|{template_existing_vpc}[View template^]
+^|{template_existing_cluster}[View template^]
+|===
+New clusters take about 1.5 hours to deploy. Existing clusters take about {deployment_time} to deploy.
+
+WARNING: If you deploy {partner-product-short-name} into an existing VPC, ensure that any private subnets have https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html[NAT gateways^] in their route tables to allow the Quick Start to download packages and software. Also, ensure that the domain name in the DHCP options is configured. For more information, see http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html[DHCP options sets^].
+
+[start=2]
+. Check the AWS Region that’s displayed in the upper-right corner of the navigation bar, and change it if necessary. This is where the network infrastructure for {partner-product-short-name} is built. The template launches in the {default_deployment_region} Region by default.
+. On the *Create stack* page, keep the default setting for the template URL, and then choose *Next*.
+. On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. A reference
+//TODO A reference for what?
+ is provided in the link:#_parameter_reference[Parameter reference] section. Provide values for the parameters that require input. For all other parameters, review the default settings, and customize them as necessary.
+
+. On the *Options* page, specify the https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[key-value pairs^] for resources in your stack, and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re done, choose *Next*.
+. On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
+. Choose *Create stack* to deploy the stack.
+ifndef::partner-product-short-name[. Monitor the status of the stack. When the status is *CREATE_COMPLETE*, the {partner-product-name} deployment is ready.]
+ifdef::partner-product-short-name[. Monitor the status of the stack. When the status is *CREATE_COMPLETE*, the {partner-product-short-name} deployment is ready.]
+. Use the values displayed in the *Outputs* tab for the stack, as shown in the following figure.
+
+:xrefstyle: short
+[#cfn_outputs]
+ifndef::partner-product-short-name[.{partner-product-name} outputs after successful deployment]
+ifdef::partner-product-short-name[.{partner-product-short-name} outputs after successful deployment]
+[link=images/cfn_outputs.png]
+image::../images/cfn_outputs.png[cfn_outputs,width=648,height=439]

--- a/index.adoc
+++ b/index.adoc
@@ -20,5 +20,18 @@ ifndef::partner-company-name[:partner-company-footer:]
 :docinfodir: boilerplate
 :docinfo:
 
+ifndef::custom_title[]
 :title: {partner-product-name} on the AWS Cloud
-ifdef::project_cfn[include::{includedir}/_layout_cfn.adoc[]]
+endif::custom_title[]
+ifdef::custom_title[]
+:title: {custom_title}
+endif::custom_title[]
+
+ifdef::project_cfn[]
+ifndef::eks_addin[]
+include::{includedir}/_layout_cfn.adoc[]
+endif::eks_addin[]
+ifdef::eks_addin[]
+include::{includedir}/_layout_cfn_eks_module.adoc[]
+endif::eks_addin[]
+endif::project_cfn[]

--- a/planning_deployment_eks_module.adoc
+++ b/planning_deployment_eks_module.adoc
@@ -1,0 +1,42 @@
+=== Specialized knowledge
+
+This deployment guide requires a moderate level of familiarity with
+AWS services. If you’re new to AWS, see the https://aws.amazon.com/getting-started/[Getting Started Resource Center^]
+and https://aws.amazon.com/training/[AWS Training and Certification^]. These sites provide materials for learning how to design,
+deploy, and operate your infrastructure and applications on the AWS Cloud.
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/specialized_knowledge.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/specialized_knowledge.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+=== AWS account
+
+If you don’t already have an AWS account, create one at https://aws.amazon.com/[https://aws.amazon.com^] by following the on-screen instructions. Part of the sign-up process involves receiving a phone call and entering a PIN using your phone's keypad.
+
+Your AWS account is automatically signed up for all AWS services. You are charged only for the services you use.
+
+=== Amazon EKS cluster
+
+If you deploy your cluster into an existing Amazon EKS cluster that was not created by the https://aws-quickstart.github.io/quickstart-amazon-eks/[Amazon EKS on the AWS Cloud^] Quick Start, you must configure your cluster to allow this Quick Start to manage it. For more information, see the link:#_deployment_steps[Deployment steps] section.
+
+
+=== IAM permissions
+//TODO: scope of least-privilege
+Before launching the Quick Start, you must log in to the AWS Management Console with https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[AWS Identity and Access Management (IAM)^] permissions for the resources and actions that each template deploys.
+
+The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions.
+
+=== Deployment options
+
+This Quick Start provides three deployment options:
+
+* *Deploy {partner-product-short-name} into a new VPC (end-to-end deployment)*. This option builds a new AWS environment consisting of the VPC, subnets, NAT gateways, security groups, bastion hosts, EKS cluster, a node group, and other infrastructure components. It then deploys {partner-product-short-name} into this new EKS cluster.
+* *Deploy {partner-product-short-name} into a new EKS cluster of an existing VPC*. This option builds a new Amazon EKS cluster, node group, and other infrastructure components into an existing VPC. It then deploys {partner-product-short-name} into this new EKS cluster.
+* *Deploy {partner-product-short-name} into an existing EKS cluster*. This option provisions {partner-product-short-name} in your existing AWS infrastructure. Note that when deploying into an EKS cluster that was not created by the https://aws-quickstart.github.io/quickstart-amazon-eks/[Amazon EKS on the AWS Cloud^] Quick Start, you must prepare the cluster as described in the link:#_deployment_steps[Deployment steps] section.


### PR DESCRIPTION
Up until now, eks addins (like [Snyk controller for Amazon EKS](https://aws-quickstart.github.io/quickstart-eks-snyk/)) have had their boilerplate based off a dedicated branch (`eks`) of this repo. This results in extra work keeping the `eks` branch up to date with changes to `main`.

This pr allows eks addin quickstarts to consume main branch of this repo. Setting `:eks_addin:` in `docs/partner_editable/_settings.adoc` identifies a repo as an eks addin. Existing eks addins need only change their submodule branch and do an update.

This is achieved by having a dedicated layout file, that points to dedicated boilerplate files where required, while trying to keep as much of the standard boilerplate where possible. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
