### PR TITLE
Swapping out mv for rsync

### DIFF
--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -30,7 +30,7 @@ function build_prod_example_docs(){
 ASCIIDOC_ATTRIBUTES=""
 GITHUB_REPO_OWNER=$(echo ${GITHUB_REPOSITORY} | cut -d '/' -f 1)
 if [ -d docs/images ]; then
-  mv docs/images images
+  rsync -avP docs/images/ images/
 fi
 
 if [ -f docs/index.html ]; then


### PR DESCRIPTION
Currently if `images/` exists, the current command will move images from `docs/images` into `images/images`.

This PR swaps out `mv` for `rsync` so that content from `docs/images` is placed in `images`, regardless if it exists or not.

Note: Existing files will be overridden in `images` for the purposes of doc builds, but otherwise be left alone, as current automation leaves content in `gh-pages`.