### PR TITLE
Update _layout_cfn.adoc

### DIFF
--- a/_layout_cfn.adoc
+++ b/_layout_cfn.adoc
@@ -23,7 +23,7 @@ ifndef::production_build[]
 |===
 endif::production_build[]
 
-== Cost
+== AWS costs
 include::../{includedir}/cost.adoc[]
 
 ifndef::disable_licenses[]

--- a/cost.adoc
+++ b/cost.adoc
@@ -1,5 +1,5 @@
 
-You are responsible for the cost of the AWS services and paid third-party licenses used while running this Quick Start. There is no additional cost for
+You are responsible for the cost of the AWS services and any paid third-party licenses used while running this Quick Start. There is no additional cost for
 using the Quick Start.
 
 The AWS CloudFormation templates for Quick Starts include

--- a/cost.adoc
+++ b/cost.adoc
@@ -1,6 +1,5 @@
 
-You are responsible for the cost of the AWS services used while running
-this Quick Start. There is no additional cost for
+You are responsible for the cost of the AWS services and paid third-party licenses used while running this Quick Start. There is no additional cost for
 using the Quick Start.
 
 The AWS CloudFormation templates for Quick Starts include


### PR DESCRIPTION
During a recent legal review, Tad provided feedback about the "Cost" section in the guides, recommending that we call out Partner costs here as well. Since this is boilerplate content that is common to all guides, I think the easiest solution to avoid ambiguity is to simply rename the section from "Costs" to "AWS costs." This way, users know we aren't calling out any Partner costs here. It's just AWS costs. Small change, but I think it's valid. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
