### PR TITLE
Updated "Technical requirements" lead-in in two files

### DIFF
--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -25,7 +25,7 @@ Your AWS account is automatically signed up for all AWS services. You are charge
 ifndef::disable_requirements[]
 === Technical requirements
 
-Before you launch the Quick Start, review the following information and make sure that your account is properly configured. Otherwise, deployment might fail.
+Before you launch the Quick Start, review the following information and ensure that your account is properly configured. Otherwise, deployment might fail.
 endif::disable_requirements[]
 
 ==== Resource quotas

--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -25,7 +25,7 @@ Your AWS account is automatically signed up for all AWS services. You are charge
 ifndef::disable_requirements[]
 === Technical requirements
 
-Before you launch the Quick Start, your account must be configured as specified in the following table. Otherwise, deployment might fail.
+Before you launch the Quick Start, review the following information and make sure that your account is properly configured. Otherwise, deployment might fail.
 endif::disable_requirements[]
 
 ==== Resource quotas

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -22,7 +22,7 @@ Your AWS account is automatically signed up for all AWS services. You are charge
 ifndef::disable_requirements[]
 === Technical requirements
 
-Before you launch the Quick Start, your account must be configured as specified in the following table. Otherwise, deployment might fail.
+Before you launch the Quick Start, review the following information and make sure that your account is properly configured. Otherwise, deployment might fail.
 endif::disable_requirements[]
 
 ==== Resource quotas

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -22,7 +22,7 @@ Your AWS account is automatically signed up for all AWS services. You are charge
 ifndef::disable_requirements[]
 === Technical requirements
 
-Before you launch the Quick Start, review the following information and make sure that your account is properly configured. Otherwise, deployment might fail.
+Before you launch the Quick Start, review the following information and ensure that your account is properly configured. Otherwise, deployment might fail.
 endif::disable_requirements[]
 
 ==== Resource quotas


### PR DESCRIPTION
In both `planning_deployment` files, rephrased the lead-in under "Technical requirements" to eliminate the reference to "the following table" since we no longer use a table format for that information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
