### PR TITLE
Awk to capture both variants of the commit ID

### DIFF
--- a/.utils/docs_built_in_codebuild.sh
+++ b/.utils/docs_built_in_codebuild.sh
@@ -50,7 +50,7 @@ rm -rf ${WORKING_DIR}/docs/boilerplate
 unzip ${DL_DIR}/boilerplate.zip -d ${WORKING_DIR}/docs/boilerplate || exit 150
 
 cd ${WORKING_DIR}
-doc_commit_id=$(git submodule | grep docs/boilerplate | cut -d - -f 2 | cut -f 1 -d " ")
+doc_commit_id=$(git submodule | grep docs/boilerplate | cut -d - -f 2 | awk '{print $1}')
 if [ -z "${doc_commit_id}" ]; then
   echo "docs/boilerplate submodule not found. exiting"
   exit 150


### PR DESCRIPTION
I had a nice awesome explaination but it didn't take, so..

TLDR:

- The current mechanism for identifying the submodule commit id for `docs/boilerplate` assumes the submodule has _not_ been initialized. That's now a false assumption. This PR leverages awk to catch both use cases

```
❯ git submodule
-0ed73f22f2ea225fb62a8e20369423c77d41ba57 docs/boilerplate
❯ git submodule | grep docs/boilerplate | cut -d - -f 2 | awk '{print $1}'
0ed73f22f2ea225fb62a8e20369423c77d41ba57
```

```
❯ git submodule
 0ed73f22f2ea225fb62a8e20369423c77d41ba57 docs/boilerplate (heads/main)
❯ git submodule | grep docs/boilerplate | cut -d - -f 2 | awk '{print $1}'
0ed73f22f2ea225fb62a8e20369423c77d41ba57
```

## Current Behavior

```
❯ git submodule
 0ed73f22f2ea225fb62a8e20369423c77d41ba57 docs/boilerplate (heads/main)
❯ git submodule | grep docs/boilerplate | cut -d - -f 2 | cut -f 1 -d " "

```

```
❯ git submodule
-0ed73f22f2ea225fb62a8e20369423c77d41ba57 docs/boilerplate
❯ git submodule | grep docs/boilerplate | cut -d - -f 2 | cut -f 1 -d " "
0ed73f22f2ea225fb62a8e20369423c77d41ba57
```