### PR TITLE
Tweaking doc_commit_id to reflect differnet output

### DIFF
--- a/.utils/docs_built_in_codebuild.sh
+++ b/.utils/docs_built_in_codebuild.sh
@@ -50,7 +50,8 @@ rm -rf ${WORKING_DIR}/docs/boilerplate
 unzip ${DL_DIR}/boilerplate.zip -d ${WORKING_DIR}/docs/boilerplate || exit 150
 
 cd ${WORKING_DIR}
-doc_commit_id=$(git submodule | grep docs/boilerplate | cut -d - -f 2 | awk '{print $1}')
+doc_commit_id=$(git submodule | grep docs/boilerplate | awk '{print $1}' | sed -e 's/^+//g' -e 's/^-//g')
+echo "${doc_commit_id}"
 if [ -z "${doc_commit_id}" ]; then
   echo "docs/boilerplate submodule not found. exiting"
   exit 150


### PR DESCRIPTION
Different git versions output submodule status in different ways. the version embedded into our containerized build process uses a `-` or `+` to denote submodule status. this PR trims both chars from the front of the commit ID, so the commit ID can be checked out successfully.