### PR TITLE
Adding deterministic logic to metadata attributs

### DIFF
--- a/.utils/generate_metadata_attributes.py
+++ b/.utils/generate_metadata_attributes.py
@@ -1,26 +1,38 @@
 #!/usr/bin/env python
 import io
 import cfnlint
+import sys
 from pathlib import Path
+
+custom_attributes = {
+    'deterministic_ec2_instances':[
+        'aws_ec2_instance',
+        'aws_ec2_host',
+        'aws_ec2fleet',
+        'aws_autoscaling_autoscalinggroup'
+    ]
+}
 
 def get_cfn(filename):
     _decoded, _issues = cfnlint.decode.decode(filename)
     if not _decoded:
-        print(f"Template: {filename} has an error. Run cfn-lint to determine the issue")
-        sys.exit(1)
+        raise Exception("cfn-lint failed to load {} without errors. Failure".format(filename))
     return _decoded
 
 def fetch_metadata():
     metadata_attributes = set()
     for yaml_cfn_file in Path('./templates').glob('*.template*'):
         template = get_cfn(Path(yaml_cfn_file))
-        if not template:
-            raise Exception(f"cfn-lint failed to load {yaml_cfn_file} without errors. Failure")
         _resources = template['Resources']
         for _resource in _resources.values():
             _type = _resource['Type'].lower()
             metadata_attributes.add(_type.split('::')[1])
             metadata_attributes.add(_type.replace('::','_'))
+        for attribute, qualifying_conditions in custom_attributes.items():
+            for qc in qualifying_conditions:
+                if qc in metadata_attributes:
+                    metadata_attributes.add(attribute)
+                    break
     with open('docs/generated/services/metadata.adoc', 'w') as f:
         f.write('\n')
         for attr in sorted(metadata_attributes):

--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -78,7 +78,7 @@ endif::auto_populate_regions[]
 TIP: Certain Regions are available on an opt-in basis. For more information, see https://docs.aws.amazon.com/general/latest/gr/rande-manage.html[Managing AWS Regions^].
 
 endif::disable_regions[]
-ifdef::template_ec2[]
+ifdef::template_deterministic_ec2_instances[]
 ==== EC2 key pairs
 ifndef::production_build[====]
 ifndef::production_build[_This section applies only if the Cloudformation templates include EC2 instances._]
@@ -86,7 +86,7 @@ ifndef::production_build[====]
 Make sure that at least one https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pair^] exists in your AWS account in the Region where you plan to deploy the Quick Start. Make note of the key pair name. You need it during deployment. To create a key pair, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pairs and Linux instances^].
 
 For testing or proof-of-concept purposes, we recommend creating a new key pair instead of using one that’s already being used by a production instance.
-endif::template_ec2[]
+endif::template_deterministic_ec2_instances[]
 
 ==== IAM permissions
 //todo: scope of least-privilege

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -75,7 +75,7 @@ endif::auto_populate_regions[]
 TIP: Certain Regions are available on an opt-in basis. See https://docs.aws.amazon.com/general/latest/gr/rande-manage.html[Managing AWS Regions^].
 
 endif::disable_regions[]
-ifdef::template_ec2[]
+ifdef::template_deterministic_ec2_instances[]
 ==== EC2 key pairs
 ifndef::production_build[====]
 ifndef::production_build[_This section applies only if the Cloudformation templates include EC2 instances._]
@@ -83,7 +83,7 @@ ifndef::production_build[====]
 Make sure that at least one https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pair^] exists in your AWS account in the Region where you plan to deploy the Quick Start. Make note of the key pair name. You need it during deployment. To create a key pair, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[Amazon EC2 key pairs and Linux instances^].
 
 For testing or proof-of-concept purposes, we recommend creating a new key pair instead of using one that’s already being used by a production instance.
-endif::template_ec2[]
+endif::template_deterministic_ec2_instances[]
 
 ==== IAM permissions
 //todo: scope of least-privilege


### PR DESCRIPTION
Our condition around EC2 key relies on the `template_ec2` attribute, not `template_ec2_instances`; However, several resource types result in an EC2 instance. This PR modifies our generation to enable deterministic conditions. I've also modified references of `template_ec2` to `template_deterministic_ec2_instances` to reflect accordingly. 

Ran through the paces on one of my projects. 