### PR TITLE
Adding checks for CDK to skip metadata generation

### DIFF
--- a/.utils/generate_dynamic_content.sh
+++ b/.utils/generate_dynamic_content.sh
@@ -10,5 +10,8 @@ if [ ${EC} -ne 0 ]; then
   echo "Gen tables"
   python docs/boilerplate/.utils/generate_parameter_tables.py
 fi
-echo "Gen metadata"
-python docs/boilerplate/.utils/generate_metadata_attributes.py
+egrep -qi '^:cdk_qs:$' docs/partner_editable/_settings.adoc; CDK=$?
+if [ ${CDK} -ne 0 ]; then
+  echo "Gen metadata"
+  python docs/boilerplate/.utils/generate_metadata_attributes.py
+fi


### PR DESCRIPTION
*Description of changes:*
looks for :cdk_qs: in _settings.adoc, and then skips 'generate_metadata_attributes.py'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
