### PR TITLE
Update deployment_steps.adoc

### DIFF
--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -24,7 +24,6 @@ include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 endif::no_parameters[]
 
-[start=5]
 . On the *Configure stack options* page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re finished, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.


### PR DESCRIPTION
*Issue #, if available:*

Due to issues with numbering, we are removing the line that force-starts the numbering at 5 in this boilerplate file. Now the list will start at 0, which is fine because the steps above it are in a separate section. This is the easiest solution to avoid numbering issues going forward. And this solution won't break guides that were previously published. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
