### PR TITLE
Updated deployment_steps docs

### DIFF
--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -1,3 +1,4 @@
+:xrefstyle: short
 
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/deploy_steps.adoc`**_
@@ -32,7 +33,6 @@ ifndef::partner-product-short-name[. Monitor the status of the stack. When the s
 ifdef::partner-product-short-name[. Monitor the status of the stack. When the status is *CREATE_COMPLETE*, the {partner-product-short-name} deployment is ready.]
 . Use the values displayed in the *Outputs* tab for the stack, as shown in <<cfn_outputs>>, to view the created resources.
 
-:xrefstyle: short
 [#cfn_outputs]
 ifndef::partner-product-short-name[.{partner-product-name} outputs after successful deployment]
 ifdef::partner-product-short-name[.{partner-product-short-name} outputs after successful deployment]

--- a/deployment_steps_eks_module.adoc
+++ b/deployment_steps_eks_module.adoc
@@ -1,3 +1,5 @@
+:xrefstyle: short
+
 === Prepare an existing EKS cluster
 NOTE: This step is only required if you launch this Quick Start into an existing Amazon EKS cluster that was not created using the https://aws-quickstart.github.io/quickstart-amazon-eks/[Amazon EKS on the AWS Cloud^] deployment. If you want to create a new EKS cluster with your deployment, skip to step 3.
 
@@ -51,7 +53,6 @@ ifndef::partner-product-short-name[. Monitor the status of the stack. When the s
 ifdef::partner-product-short-name[. Monitor the status of the stack. When the status is *CREATE_COMPLETE*, the {partner-product-short-name} deployment is ready.]
 . Use the values displayed in the *Outputs* tab for the stack, as shown in the following figure.
 
-:xrefstyle: short
 [#cfn_outputs]
 ifndef::partner-product-short-name[.{partner-product-name} outputs after successful deployment]
 ifdef::partner-product-short-name[.{partner-product-short-name} outputs after successful deployment]


### PR DESCRIPTION
In two deployment_steps docs, I bumped `:xrefstyle: short` to the top so that figure cross references generate "as shown in Figure x" instead of citing the whole figure caption.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
