### PR TITLE
Exit if index.html hasn't been generated

### DIFF
--- a/.utils/docs_built_in_codebuild.sh
+++ b/.utils/docs_built_in_codebuild.sh
@@ -67,6 +67,10 @@ if [ -d templates/ ]; then
   set +x
 fi
 
+if [ ! -f index.html ]; then
+  exit 1
+fi
+
 tmpfile=$(mktemp)
 
 echo -e "repo commit:\n$(git -P log -1 | grep 'commit' | awk '{print $2}')\n\nsubmodule config:" >> ${tmpfile}


### PR DESCRIPTION
In non-CFN based projects, the `templates/` directory needs to be stubbed out (for now) to allow docs to be built. We'll fix this later, but we do need logic to exit if the `index.html` file wasn't generated properly. (silent error)