### PR TITLE
Enabled cross-doc autonumbering for deployment steps

### DIFF
--- a/.specific/deploy_steps.adoc
+++ b/.specific/deploy_steps.adoc
@@ -1,5 +1,4 @@
-// We need to work around Step numbers here if we are going to potentially exclude the AMI subscription
-=== Sign in to your AWS account
+=== Confirm your AWS account configuration
 
 . Sign in to your AWS account at https://aws.amazon.com with an IAM user role that has the necessary permissions. For details, see link:#_planning_the_deployment[Planning the deployment] earlier in this guide.
 . Make sure that your AWS account is configured correctly, as discussed in the link:#_technical_requirements[Technical requirements] section.
@@ -26,7 +25,7 @@ WARNING: If you’re deploying {partner-product-short-name} into an existing VPC
 Each deployment takes about {deployment_time} to complete.
 
 . Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see link:#_deployment_options[Deployment options] earlier in this guide.
-
++
 [cols="3,1"]
 |===
 ^|http://qs_launch_permalink[Deploy {partner-product-short-name} into a new VPC on AWS^]
@@ -35,10 +34,7 @@ Each deployment takes about {deployment_time} to complete.
 ^|http://qs_launch_permalink[Deploy {partner-product-short-name} into an existing VPC on AWS^]
 ^|http://qs_template_permalink[View template^]
 |===
-
-[start=2]
++
 . Check the AWS Region that’s displayed in the upper-right corner of the navigation bar, and change it if necessary. This Region is where the network infrastructure for {partner-product-short-name} is built. The template is launched in the {default_deployment_region} Region by default. For other choices, see link:#_supported_regions[Supported Regions] earlier in this guide.
-
-[start=3]
 . On the *Create stack* page, keep the default setting for the template URL, and then choose *Next*.
 . On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For all other parameters, review the default settings and customize them as necessary. For details on each parameter, see the link:#_parameter_reference[Parameter reference] section of this guide. When you finish reviewing and customizing the parameters, choose *Next*.

--- a/deployment_steps.adoc
+++ b/deployment_steps.adoc
@@ -1,5 +1,5 @@
 :xrefstyle: short
-
++
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/deploy_steps.adoc`**_
 ++++
@@ -12,20 +12,19 @@ ifndef::production_build[]
 </div>
 ++++
 endif::production_build[]
-
++
 ifndef::custom_number_of_deploy_steps[]
 ifndef::no_parameters[]
 ifndef::parameters_as_appendix[]
 In the following tables, parameters are listed by category and described separately for the deployment options. When you finish reviewing and customizing the parameters, choose *Next*.
-
++
 NOTE: Unless you are customizing the Quick Start templates for your own deployment projects, keep the default settings for the parameters *Quick Start S3 bucket name*, *Quick Start S3 bucket Region*, and *Quick Start S3 key prefix*. Changing these settings automatically updates code references to point to a new Quick Start location. For more information, see the https://aws-quickstart.github.io/option1.html[AWS Quick Start Contributor’s Guide^].
-
++
 // Parameter tables linked in here
 include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 endif::no_parameters[]
-
-[start=5]
++
 . On the *Configure stack options* page, you can https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html[specify tags^] (key-value pairs) for resources in your stack and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html[set advanced options^]. When you’re finished, choose *Next*.
 . On the *Review* page, review and confirm the template settings. Under *Capabilities*, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
 . Choose *Create stack* to deploy the stack.


### PR DESCRIPTION
In `deployment_steps.adoc`, I removed `[start=5]`, which has been forcing the numbering of Step 5, and replaced the blank lines preceding this step with `+`. These changes enable autonumbering to continue from the previous doc (`deploy_steps.adoc`, from which I removed the blank line at the end to support the cross-doc autonumbering). 

Result: In most cases, Step 5 will remain Step 5. For edge cases where this needs to be Step 6 or some other number, renumbering will happen automatically without authors having to tweak the files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
