### PR TITLE
Added comments into Settings file for CDK deployment

### DIFF
--- a/.specific/_settings.adoc
+++ b/.specific/_settings.adoc
@@ -27,3 +27,6 @@
 // :marketplace_listing_url: https://example.com/
 // Uncomment the following attribute to add a statement about AWS and our stance on compliance-related Quick Starts. 
 // :compliance-statement: Deploying this Quick Start does not guarantee an organization’s compliance with any laws, certifications, policies, or other regulations.  
+// Uncomment the following two attributes if you are deploying a CDK Quick Start. Make sure to comment out :parameters_as_appendix: also.
+// :cdk_qs:
+// :no_parameters:


### PR DESCRIPTION
Added the following to the settings file for CDK deployments:

// Uncomment the following two attributes if you are deploying a CDK Quick Start. Make sure to comment out :parameters_as_appendix: also.
// :cdk_qs:
// :no_parameters:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
