### PR TITLE
Slow-rolling migration to new artifact pattern

### DIFF
--- a/.utils/docs_built_in_codebuild.sh
+++ b/.utils/docs_built_in_codebuild.sh
@@ -30,7 +30,12 @@
 #     docs/boilerplate   -- Boilerplate repo is unzipped here.
 
 function upload_preview_content(){
-  aws s3 sync --delete ${WORKING_DIR} ${DOCBUILD_DESTINATION_S3} --cache-control max-age=0,no-cache,no-store,must-revalidate --acl bucket-owner-full-control
+  aws s3 sync --delete ${WORKING_DIR} ${DOCBUILD_DESTINATION_S3} \
+    --exclude ".git" \
+    --exclude "submodules" \
+    --exclude "functions" \
+    --exclude "docs/boilerplate" \
+    --cache-control max-age=0,no-cache,no-store,must-revalidate --acl bucket-owner-full-control
 }
 
 function create_upload_ghpages_branch_archive(){


### PR DESCRIPTION
Long term strategy is to provide docs as build artifacts in CodeBuild. This logic allows a gradual onboarding.