### PR TITLE
Ensure the folder docs/generated/parameters/ exists

### DIFF
--- a/.utils/generate_dynamic_content.sh
+++ b/.utils/generate_dynamic_content.sh
@@ -8,6 +8,7 @@ egrep -qi '^:no_parameters:$' docs/partner_editable/_settings.adoc; EC=$?
 set -e
 if [ ${EC} -ne 0 ]; then
   echo "Gen tables"
+  mkdir -p docs/generated/parameters/
   python docs/boilerplate/.utils/generate_parameter_tables.py
 fi
 egrep -qi '^:cdk_qs:$' docs/partner_editable/_settings.adoc || ( echo "Gen metadata"; python docs/boilerplate/.utils/generate_metadata_attributes.py )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Document parameter tables build failing because path to write files to does not exist.

Ensure the folder `docs/generated/parameters/` exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
