### PR TITLE
Added "AWS" before "Regions" in the subhead

### DIFF
--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -47,7 +47,7 @@ include::../{generateddir}/services/metadata.adoc[]
 
 ifndef::disable_regions[]
 // We can also pull in Regions automatically.
-==== Supported Regions
+==== Supported AWS Regions
 
 ifdef::template_not_all_regions[]
 This deployment includes <service>, which isn’t currently supported in all https://aws.amazon.com/about-aws/global-infrastructure/[AWS Regions^].

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -44,7 +44,7 @@ include::../../../{generateddir}/services/metadata.adoc[]
 
 ifndef::disable_regions[]
 // We can also pull in Regions automatically.
-==== Supported Regions
+==== Supported AWS Regions
 
 ifdef::template_not_all_regions[]
 This deployment includes <service>, which isn’t currently supported in https://aws.amazon.com/about-aws/global-infrastructure/[all AWS Regions^].


### PR DESCRIPTION
Per AWS guideline to say "AWS Regions" on first mention.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
