### PR TITLE
Fixed a broken cross-ref in deploy_steps.adoc

### DIFF
--- a/.specific/deploy_steps.adoc
+++ b/.specific/deploy_steps.adoc
@@ -35,6 +35,6 @@ Each deployment takes about {deployment_time} to complete.
 ^|http://qs_template_permalink[View template^]
 |===
 +
-. Check the AWS Region that’s displayed in the upper-right corner of the navigation bar, and change it if necessary. This Region is where you build the network infrastructure. The template is launched in the {default_deployment_region} Region by default. For other choices, see link:#_supported_regions[Supported Regions] earlier in this guide.
+. Check the AWS Region that’s displayed in the upper-right corner of the navigation bar, and change it if necessary. This Region is where you build the network infrastructure. The template is launched in the {default_deployment_region} Region by default. For other choices, see link:#_supported_aws_regions[Supported AWS Regions] earlier in this guide.
 . On the *Create stack* page, keep the default setting for the template URL, and then choose *Next*.
 . On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For all other parameters, review the default settings and customize them as necessary. For details on each parameter, see the link:#_parameter_reference[Parameter reference] section of this guide. When you finish reviewing and customizing the parameters, choose *Next*.


### PR DESCRIPTION
Fixed a broken cross-ref to the "Supported AWS Regions" section earlier in the guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
