### PR TITLE
Moved "Deployment options" section to where it belongs

### DIFF
--- a/planning_deployment.adoc
+++ b/planning_deployment.adoc
@@ -94,17 +94,6 @@ endif::template_deterministic_ec2_instances[]
 //todo: scope of least-privilege
 Before launching the Quick Start, you must sign in to the AWS Management Console with IAM permissions for the resources that the templates deploy. The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions. For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[AWS managed policies for job functions^].
 
-ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/{specificdir}/pre-reqs.adoc`**_
-[.preview_mode]
-|===
-a|
-endif::production_build[]
-include::../{specificdir}/pre-reqs.adoc[]
-ifndef::production_build[]
-|===
-endif::production_build[]
-
 ==== Deployment options
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `docs/{specificdir}/deployment_options.adoc`**_
@@ -113,6 +102,17 @@ _**This portion of the deployment guide is located at `docs/{specificdir}/deploy
 a|
 endif::production_build[]
 include::../{specificdir}/deployment_options.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/{specificdir}/pre-reqs.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/pre-reqs.adoc[]
 ifndef::production_build[]
 |===
 endif::production_build[]

--- a/planning_deployment.lang.adoc
+++ b/planning_deployment.lang.adoc
@@ -91,17 +91,6 @@ endif::template_deterministic_ec2_instances[]
 //todo: scope of least-privilege
 Before launching the Quick Start, you must sign in to the AWS Management Console with IAM permissions for the resources that the templates deploy. The _AdministratorAccess_ managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions. For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html[AWS managed policies for job functions^].
 
-ifndef::production_build[]
-_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/pre-reqs.adoc`**_
-[.preview_mode]
-|===
-a|
-endif::production_build[]
-include::../{specificdir}/pre-reqs.adoc[]
-ifndef::production_build[]
-|===
-endif::production_build[]
-
 ==== Deployment options
 ifndef::production_build[]
 _**This portion of the deployment guide is located at `_**This portion of the deployment guide is located at `docs/languages/docs-{LANG_CODE}/{specificdir}/pre-reqs.adoc`**_
@@ -111,6 +100,17 @@ _**This portion of the deployment guide is located at `_**This portion of the de
 a|
 endif::production_build[]
 include::../{specificdir}/deployment_options.adoc[]
+ifndef::production_build[]
+|===
+endif::production_build[]
+
+ifndef::production_build[]
+_**This portion of the deployment guide is located at `docs/languages/{langdir}/{specificdir}/pre-reqs.adoc`**_
+[.preview_mode]
+|===
+a|
+endif::production_build[]
+include::../{specificdir}/pre-reqs.adoc[]
 ifndef::production_build[]
 |===
 endif::production_build[]


### PR DESCRIPTION
The "Deployment options" section has been in the wrong place. This became evident in docs with lots of steps in **pre-reqs.adoc**. With this change, "Deployment options" precedes the preparation steps instead of being presented as a subsection of them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
