### PR TITLE
Adding support for private repos

### DIFF
--- a/.specific/_settings.adoc
+++ b/.specific/_settings.adoc
@@ -36,5 +36,5 @@
 // :git_repo_url: https://example.com/
 // Uncomment the following attribute if you are deploying AWS Control Tower. 
 // :control_tower
-// Uncoomment the following attribute if your repo is going to stay private after publishing.
+// Uncomment the following attribute if your repo is going to stay private after publishing.
 // :private_repo:

--- a/.specific/_settings.adoc
+++ b/.specific/_settings.adoc
@@ -36,3 +36,5 @@
 // :git_repo_url: https://example.com/
 // Uncomment the following attribute if you are deploying AWS Control Tower. 
 // :control_tower
+// Uncoomment the following attribute if your repo is going to stay private after publishing.
+// :private_repo:

--- a/_layout_cfn.adoc
+++ b/_layout_cfn.adoc
@@ -113,7 +113,7 @@ endif::private_repo[]
 
 ifdef::private_repo[]
 == Send us feedback
-If you have feedback, feature ideas about this quick start please send to quickstart@amazon.com
+If you have feedback about this Quick Start, such as a feature idea or a bug you've found, please email quickstart@amazon.com.
 endif::private_repo[]
 
 == Quick Start reference deployments

--- a/_layout_cfn.adoc
+++ b/_layout_cfn.adoc
@@ -105,15 +105,22 @@ include::../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 endif::no_parameters[]
 
+ifndef::private_repo[]
 == Send us feedback
 
 To post feedback, submit feature ideas, or report bugs, use the *Issues* section of the https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] for this Quick Start. To submit code, see the https://aws-quickstart.github.io/[Quick Start Contributor’s Guide^].
+endif::private_repo[]
+
+ifdef::private_repo[]
+== Send us feedback
+If you have feedback, feature ideas about this quick start please send to quickstart@amazon.com
+endif::private_repo[]
 
 == Quick Start reference deployments
 
 See the https://aws.amazon.com/quickstart/[AWS Quick Start home page^].
 
-
+ifndef::private_repo[]
 == GitHub repository
 
 Visit our https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] to download
@@ -121,4 +128,6 @@ the templates and scripts for this Quick Start, to post your comments,
 and to share your customizations with others.
 
 '''
+endif::private_repo[]
+
 include::../{includedir}/disclaimer.adoc[]

--- a/_layout_cfn.adoc
+++ b/_layout_cfn.adoc
@@ -113,7 +113,7 @@ endif::private_repo[]
 
 ifdef::private_repo[]
 == Send us feedback
-If you have feedback about this Quick Start, such as a feature idea or a bug you've found, please email quickstart@amazon.com.
+If you have feedback about this Quick Start, such as a feature idea or a bug you've found, email quickstart@amazon.com.
 endif::private_repo[]
 
 == Quick Start reference deployments

--- a/_layout_cfn.lang.adoc
+++ b/_layout_cfn.lang.adoc
@@ -109,7 +109,7 @@ endif::private_repo[]
 
 ifdef::private_repo[]
 == Send us feedback
-If you have feedback, feature ideas about this quick start please send to quickstart@amazon.com
+If you have feedback about this Quick Start, such as a feature idea or a bug you've found, email quickstart@amazon.com.
 endif::private_repo[]
 
 == Quick Start reference deployments

--- a/_layout_cfn.lang.adoc
+++ b/_layout_cfn.lang.adoc
@@ -101,15 +101,22 @@ include::../../{generateddir}/parameters/index.adoc[]
 endif::parameters_as_appendix[]
 endif::no_parameters[]
 
+ifndef::private_repo[]
 == Send us feedback
 
 To post feedback, submit feature ideas, or report bugs, use the *Issues* section of the https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] for this Quick Start. To submit code, see the https://aws-quickstart.github.io/[Quick Start Contributor’s Guide^].
+endif::private_repo[]
+
+ifdef::private_repo[]
+== Send us feedback
+If you have feedback, feature ideas about this quick start please send to quickstart@amazon.com
+endif::private_repo[]
 
 == Quick Start reference deployments
 
 See the https://aws.amazon.com/quickstart/[AWS Quick Start home page^].
 
-
+ifndef::private_repo[]
 == GitHub repository
 
 Visit our https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] to download
@@ -117,4 +124,5 @@ the templates and scripts for this Quick Start, to post your comments,
 and to share your customizations with others.
 
 '''
+endif::private_repo[]
 include::translate-only/disclaimer.adoc[]

--- a/introduction.adoc
+++ b/introduction.adoc
@@ -33,8 +33,10 @@ ifndef::production_build[]
 |===
 endif::production_build[]
 
+ifndef::private_repo[]
 TIP: Visit our https://github.com/aws-quickstart/{quickstart-project-name}[GitHub repository^] for source files and to post feedback,
 report bugs, or submit feature ideas for this Quick Start.
+ifndef::private_repo[]
 
 ifdef::partner-company-name[]
 [.text-left]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a new parameter to check if the repo is private for whatever the reason (ex: SaaS workloads, Strategic engagements) and then hiding github related links in the generated guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
