### PR TITLE
Fixing parameter description, default value formatting in asciidoc fo…

### DIFF
--- a/.utils/generate_parameter_tables.py
+++ b/.utils/generate_parameter_tables.py
@@ -103,8 +103,9 @@ def just_pass():
                 param_data = _generate_per_label_table_entry(
                         parameter_labels.get(lparam, ''),
                         lparam,
-                        parameter_mappings[lparam].get('Default', determine_optional_value(lparam)),
-                        parameter_mappings[lparam].get('Description', 'NO_DESCRIPTION')
+                        parameter_mappings[lparam].get('Default', determine_optional_value(lparam)).replace('*', '\*', 1).replace('|', '\|'),# replace is to escape the pipe character and astrix in parameter parameter default values
+                        parameter_mappings[lparam].get('Description', 'NO_DESCRIPTION').replace('*', '\*', 1).replace('|', '\|') # replace is to escape the pipe character and astrix in parameter description
+
                 )
                 adoc_data += param_data
             adoc_data += "\n|==="


### PR DESCRIPTION


*Description of changes:*

> `Fixing parameter description, default value formatting in asciidoc for * and |`

tested it on sumo logic quick starts which as these cases. working fine.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
