### PR TITLE
Adding in aws-ia to list of repo owners

### DIFF
--- a/.utils/build_docs.sh
+++ b/.utils/build_docs.sh
@@ -37,7 +37,7 @@ if [ -f docs/index.html ]; then
   rm docs/index.html
 fi
 
-if [ "${GITHUB_REPO_OWNER}" == "aws-quickstart" ]; then
+if [ "${GITHUB_REPO_OWNER}" == "aws-quickstart" ] || [ "${GITHUB_REPO_OWNER}" == "aws-ia" ]; then
   cp docs/boilerplate/.css/AWS-Logo.svg images/
   if [ "${GITHUB_REF}" == "refs/heads/master" ] || [ "${GITHUB_REF}" == "refs/heads/main" ];  then
     _set_prod_asciidoc_attributes


### PR DESCRIPTION
Doc builds in IA appear as preview. This enables them to be production builds


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
